### PR TITLE
OPHJOD-264: Correlate application logs with CF access logs

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/config/AwsCloudFrontRequestIdFilter.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/AwsCloudFrontRequestIdFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.MDC;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Adds CloudFront request id to MDC.
+ *
+ * <p>Makes it possible to correlate requests with CF access logs.
+ */
+@Component
+@Profile("cloud")
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class AwsCloudFrontRequestIdFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain)
+      throws ServletException, IOException {
+
+    // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior
+    var cfId = request.getHeader("X-Amz-Cf-Id");
+    if (cfId != null) {
+      MDC.put("amzCfId", cfId);
+    }
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/fi/okm/jod/yksilo/controller/PingController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/PingController.java
@@ -23,6 +23,7 @@ public class PingController {
 
   @GetMapping(produces = MediaType.TEXT_PLAIN_VALUE)
   public String ping() {
+    log.info("Ping received");
     return "pong";
   }
 }

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -3,7 +3,7 @@ spring:
     type: fi.okm.jod.yksilo.config.datasource.RdsIamAuthHikariDataSource
 
 server:
-  forward-headers-strategy: native
+  forward-headers-strategy: none
   shutdown: graceful
   error:
     include-stacktrace: never


### PR DESCRIPTION
## Description
Adds CloudFront request id to logs, making it possible to correate logs with CF access logs which include the client IP.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-264
