### PR TITLE
OPHJOD-486: Koulutus apin refaktorointi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ checkstyle {
 
 spotless {
   java {
+    target 'src/*/**/*.java'
     googleJavaFormat()
     licenseHeader '''\
     /*

--- a/src/main/java/fi/okm/jod/yksilo/dto/profiili/KoulutusKategoriaDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/profiili/KoulutusKategoriaDto.java
@@ -10,10 +10,11 @@
 package fi.okm.jod.yksilo.dto.profiili;
 
 import fi.okm.jod.yksilo.validation.Limits;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import java.util.Set;
 
 public record KoulutusKategoriaDto(
-    @Valid KategoriaDto kategoria,
+    @Valid @Nullable KategoriaDto kategoria,
     @Size(max = Limits.KOULUTUS) Set<@Valid KoulutusDto> koulutukset) {}

--- a/src/main/java/fi/okm/jod/yksilo/repository/KoulutusKategoriaRepository.java
+++ b/src/main/java/fi/okm/jod/yksilo/repository/KoulutusKategoriaRepository.java
@@ -12,6 +12,7 @@ package fi.okm.jod.yksilo.repository;
 import fi.okm.jod.yksilo.entity.KoulutusKategoria;
 import fi.okm.jod.yksilo.entity.Yksilo;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -20,6 +21,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface KoulutusKategoriaRepository extends JpaRepository<KoulutusKategoria, UUID> {
 
   List<KoulutusKategoria> findAllByYksilo(Yksilo yksilo);
+
+  Optional<KoulutusKategoria> findByYksiloAndId(Yksilo yksilo, UUID id);
 
   @Query(
       """

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/Mapper.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/Mapper.java
@@ -30,11 +30,11 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-final class Mapper {
+public final class Mapper {
 
   private Mapper() {}
 
-  static ToimenkuvaDto mapToimenkuva(Toimenkuva entity) {
+  public static ToimenkuvaDto mapToimenkuva(Toimenkuva entity) {
     return entity == null
         ? null
         : new ToimenkuvaDto(
@@ -48,7 +48,7 @@ final class Mapper {
                 .collect(Collectors.toUnmodifiableSet()));
   }
 
-  static TyopaikkaDto mapTyopaikka(Tyopaikka entity) {
+  public static TyopaikkaDto mapTyopaikka(Tyopaikka entity) {
     return entity == null
         ? null
         : new TyopaikkaDto(
@@ -59,7 +59,7 @@ final class Mapper {
                 .collect(Collectors.toSet()));
   }
 
-  static KoulutusDto mapKoulutus(Koulutus entity) {
+  public static KoulutusDto mapKoulutus(Koulutus entity) {
     return entity == null
         ? null
         : new KoulutusDto(
@@ -73,19 +73,19 @@ final class Mapper {
                 .collect(Collectors.toUnmodifiableSet()));
   }
 
-  static KategoriaDto mapKategoria(KoulutusKategoria entity) {
+  public static KategoriaDto mapKategoria(KoulutusKategoria entity) {
     return entity == null
         ? null
         : new KategoriaDto(entity.getId(), entity.getNimi(), entity.getKuvaus());
   }
 
-  static OsaaminenDto mapOsaaminen(Osaaminen entity) {
+  public static OsaaminenDto mapOsaaminen(Osaaminen entity) {
     return entity == null
         ? null
         : new OsaaminenDto(URI.create(entity.getUri()), entity.getNimi(), entity.getKuvaus());
   }
 
-  static YksilonOsaaminenDto mapYksilonOsaaminen(YksilonOsaaminen entity) {
+  public static YksilonOsaaminenDto mapYksilonOsaaminen(YksilonOsaaminen entity) {
     return entity == null
         ? null
         : new YksilonOsaaminenDto(

--- a/src/test/java/fi/okm/jod/yksilo/service/KoulutusServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/KoulutusServiceTest.java
@@ -10,24 +10,173 @@
 package fi.okm.jod.yksilo.service;
 
 import static fi.okm.jod.yksilo.testutil.LocalizedStrings.ls;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.dto.profiili.KategoriaDto;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusDto;
 import fi.okm.jod.yksilo.service.profiili.KoulutusService;
 import fi.okm.jod.yksilo.service.profiili.YksilonOsaaminenService;
 import java.net.URI;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.util.Pair;
 import org.springframework.test.context.jdbc.Sql;
 
 @Sql("/data/osaaminen.sql")
 @Import({KoulutusService.class, YksilonOsaaminenService.class})
 class KoulutusServiceTest extends AbstractServiceTest {
 
+  private static final UUID TEST_KOULUTUS_1_UUID =
+      UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID TEST_KATEGORIA_1_UUID =
+      UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID TEST_USER_1_UUID =
+      UUID.fromString("00000000-0000-0000-0000-000000000001");
+
   @Autowired KoulutusService service;
+
+  @Test
+  void shouldAddKoulutusWithKategoria() {
+    assertDoesNotThrow(
+        () -> {
+          var before = service.findAll(user);
+          var resultDto =
+              service.create(
+                  user,
+                  new KategoriaDto(null, ls("kategoria"), null),
+                  Set.of(
+                      new KoulutusDto(
+                          null,
+                          ls("nimi"),
+                          null,
+                          null,
+                          null,
+                          Set.of(URI.create("urn:osaaminen1")))));
+          entityManager.flush();
+
+          assertNotNull(resultDto.kategoria());
+          var after = service.findAll(user);
+          assertTrue(before.size() < after.size());
+          assertTrue(
+              after.stream()
+                  .allMatch(
+                      p ->
+                          p.kategoria().id() != null
+                              && !p.koulutukset().isEmpty()
+                              && p.koulutukset().stream().allMatch(k -> k.id() != null)));
+        });
+  }
+
+  @Sql(
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+      scripts = "/data/create/koulutus-test-data.sql")
+  @Sql(
+      executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
+      scripts = "/data/delete/koulutus-test-data.sql")
+  @Test
+  void shouldUpdateKoulutusWithoutKategoria() {
+    assertDoesNotThrow(
+        () -> {
+          var user = TestJodUser.of(TEST_USER_1_UUID.toString());
+          var oldKoulutus =
+              service.find(user, TEST_KOULUTUS_1_UUID).koulutukset().stream()
+                  .filter(k -> k.id().equals(TEST_KOULUTUS_1_UUID))
+                  .findFirst()
+                  .get();
+          var newOsaamiset =
+              Set.of(
+                  URI.create("urn:osaaminen1"),
+                  URI.create("urn:osaaminen2"),
+                  URI.create("urn:osaaminen7"));
+
+          var koulutusToPatch =
+              new KoulutusDto(
+                  TEST_KOULUTUS_1_UUID,
+                  ls(
+                      Pair.of(Kieli.FI, "uusi nimi"),
+                      Pair.of(Kieli.EN, "new name"),
+                      Pair.of(Kieli.SV, "nya namn")),
+                  ls(
+                      Pair.of(Kieli.FI, "uusi kuvaus"),
+                      Pair.of(Kieli.EN, "new description"),
+                      Pair.of(Kieli.SV, "nya beskrivning")),
+                  oldKoulutus.alkuPvm(),
+                  oldKoulutus.loppuPvm(),
+                  newOsaamiset);
+          var resultDto = service.update(user, koulutusToPatch);
+          entityManager.flush();
+
+          assertNotNull(resultDto.koulutukset());
+          assertNull(resultDto.kategoria());
+
+          var updatedKoulutus =
+              service.find(user, TEST_KOULUTUS_1_UUID).koulutukset().stream()
+                  .filter(k -> k.id().equals(TEST_KOULUTUS_1_UUID))
+                  .findFirst()
+                  .get();
+          assertNotNull(updatedKoulutus);
+
+          assertEquals("uusi nimi", updatedKoulutus.nimi().get(Kieli.FI));
+          assertEquals("new name", updatedKoulutus.nimi().get(Kieli.EN));
+          assertEquals("nya namn", updatedKoulutus.nimi().get(Kieli.SV));
+
+          assertEquals("uusi kuvaus", updatedKoulutus.kuvaus().get(Kieli.FI));
+          assertEquals("new description", updatedKoulutus.kuvaus().get(Kieli.EN));
+          assertEquals("nya beskrivning", updatedKoulutus.kuvaus().get(Kieli.SV));
+
+          assertEquals(newOsaamiset, updatedKoulutus.osaamiset());
+        });
+  }
+
+  @Sql(
+      executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+      scripts = "/data/create/kategoria-test-data.sql")
+  @Sql(
+      executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
+      scripts = "/data/delete/kategoria-test-data.sql")
+  @Test
+  void shouldUpdateKategoria() {
+    assertDoesNotThrow(
+        () -> {
+          var user = TestJodUser.of(TEST_USER_1_UUID.toString());
+          var kategoriaToPatch =
+              new KategoriaDto(
+                  TEST_KATEGORIA_1_UUID,
+                  ls(
+                      Pair.of(Kieli.FI, "uusi nimi"),
+                      Pair.of(Kieli.EN, "new name"),
+                      Pair.of(Kieli.SV, "nya namn")),
+                  ls(
+                      Pair.of(Kieli.FI, "uusi kuvaus"),
+                      Pair.of(Kieli.EN, "new description"),
+                      Pair.of(Kieli.SV, "nya beskrivning")));
+          var resultDto = service.update(user, kategoriaToPatch);
+          entityManager.flush();
+
+          assertNull(resultDto.koulutukset());
+          assertNotNull(resultDto.kategoria());
+
+          var updatedKategoria = service.findKategoriaById(user, TEST_KATEGORIA_1_UUID).kategoria();
+          assertNotNull(updatedKategoria);
+
+          assertEquals("uusi nimi", updatedKategoria.nimi().get(Kieli.FI));
+          assertEquals("new name", updatedKategoria.nimi().get(Kieli.EN));
+          assertEquals("nya namn", updatedKategoria.nimi().get(Kieli.SV));
+
+          assertEquals("uusi kuvaus", updatedKategoria.kuvaus().get(Kieli.FI));
+          assertEquals("new description", updatedKategoria.kuvaus().get(Kieli.EN));
+          assertEquals("nya beskrivning", updatedKategoria.kuvaus().get(Kieli.SV));
+        });
+  }
 
   @Test
   void shouldAddAndUpdateKoulutus() {

--- a/src/test/java/fi/okm/jod/yksilo/testutil/LocalizedStrings.java
+++ b/src/test/java/fi/okm/jod/yksilo/testutil/LocalizedStrings.java
@@ -11,7 +11,10 @@ package fi.okm.jod.yksilo.testutil;
 
 import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.domain.LocalizedString;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.data.util.Pair;
 
 public interface LocalizedStrings {
   static LocalizedString ls(String s) {
@@ -20,6 +23,12 @@ public interface LocalizedStrings {
 
   static LocalizedString ls(Kieli k, String s) {
     return new LocalizedString(Map.of(k, s));
+  }
+
+  @SafeVarargs
+  static LocalizedString ls(Pair<Kieli, String>... values) {
+    return new LocalizedString(
+        Arrays.stream(values).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)));
   }
 
   static LocalizedString ls(Kieli k, String s, Kieli k2, String s2) {

--- a/src/test/resources/data/create/kategoria-test-data.sql
+++ b/src/test/resources/data/create/kategoria-test-data.sql
@@ -1,0 +1,17 @@
+-- TEST YKSILO DATA
+INSERT INTO yksilo (id, tunnus)
+VALUES ('00000000-0000-0000-0000-000000000001', 'test_user1'),
+       ('00000000-0000-0000-0000-000000000002', 'test_user2'),
+       ('00000000-0000-0000-0000-000000000003', 'test_user3');
+
+-- TEST KATEGORIA DATA
+insert into koulutus_kategoria (id, yksilo_id) values ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001');
+
+insert into koulutus_kategoria_kaannos (koulutus_kategoria_id, kaannos_key, nimi, kuvaus)
+values
+  ( '00000000-0000-0000-0000-000000000001', 'FI', 'kategoria fi', 'kategoria 1 kuvaus fi'),
+  ( '00000000-0000-0000-0000-000000000001', 'SV', 'kategoria sv', 'kategoria 1 kuvaus sv'),
+  ( '00000000-0000-0000-0000-000000000001', 'EN', 'kategoria en', 'kategoria 1 kuvaus en');
+
+
+

--- a/src/test/resources/data/create/koulutus-test-data.sql
+++ b/src/test/resources/data/create/koulutus-test-data.sql
@@ -1,0 +1,29 @@
+INSERT INTO osaaminen(id, uri)
+VALUES (1, 'urn:osaaminen1'),
+       (2, 'urn:osaaminen2'),
+       (3, 'urn:osaaminen3'),
+       (4, 'urn:osaaminen4'),
+       (5, 'urn:osaaminen5'),
+       (6, 'urn:osaaminen6'),
+       (7, 'urn:osaaminen7');
+
+-- TEST YKSILO DATA
+INSERT INTO yksilo (id, tunnus)
+VALUES ('00000000-0000-0000-0000-000000000001', 'test_user1'),
+       ('00000000-0000-0000-0000-000000000002', 'test_user2'),
+       ('00000000-0000-0000-0000-000000000003', 'test_user3');
+
+-- TEST KOULUTUS DATA FOR test_user1
+insert into koulutus (id, alku_pvm, loppu_pvm, yksilo_id) values ('00000000-0000-0000-0000-000000000001', now()::date, now()::date, '00000000-0000-0000-0000-000000000001');
+insert into koulutus (id, alku_pvm, loppu_pvm, yksilo_id) values ('00000000-0000-0000-0000-000000000002', now()::date, now()::date, '00000000-0000-0000-0000-000000000001');
+insert into koulutus (id, alku_pvm, loppu_pvm, yksilo_id) values ('00000000-0000-0000-0000-000000000003', now()::date, now()::date, '00000000-0000-0000-0000-000000000001');
+
+
+insert into koulutus_kaannos (koulutus_id, kaannos_key, nimi, kuvaus)
+values
+  ( '00000000-0000-0000-0000-000000000001', 'FI', 'koulutus1 fi', 'koulutus 1 kuvaus fi'),
+  ( '00000000-0000-0000-0000-000000000001', 'SV', 'koulutus1 sv', 'koulutus 1 kuvaus sv'),
+  ( '00000000-0000-0000-0000-000000000001', 'EN', 'koulutus1 en', 'koulutus 1 kuvaus en');
+
+
+

--- a/src/test/resources/data/delete/kategoria-test-data.sql
+++ b/src/test/resources/data/delete/kategoria-test-data.sql
@@ -1,0 +1,6 @@
+-- CLEAR TEST DATA
+DELETE FROM koulutus_kategoria_kaannos;
+DELETE FROM koulutus_kategoria;
+DELETE FROM yksilo;
+
+

--- a/src/test/resources/data/delete/koulutus-test-data.sql
+++ b/src/test/resources/data/delete/koulutus-test-data.sql
@@ -1,0 +1,7 @@
+-- CLEAR TEST DATA
+DELETE FROM yksilon_osaaminen;
+DELETE FROM koulutus_kaannos;
+DELETE FROM koulutus;
+DELETE FROM yksilo;
+
+


### PR DESCRIPTION
API:n ajateltu käyttö (muutosten jälkeen):

GET /api/profiili/koulutukset palauttaa tarvittavat tiedot koulutusten yleisnäkymään
POST /api/profiili/koulutukset toimii uuden koulutuksen (tai kokonaisen uuden kategorian) lisäämiseen.
Siirryttäessä muokkaukseen yleisnäkymästä ei välttämättä tarvitse ladata tietoja uudelleen koska (1) palauttaa samat tiedot. Tähän voi kuitenkin käyttää GET /api/profiili/kategoria/id tai GET /api/profiili/koulutukset/{id} (koulutuksille joilla ei ole kategoriaa) API:a
Kun tunnistetaan koulutuksen osaamisia, GET /api/profiili/koulutukset/id palauttaa yksittäisen koulutuksen osaamiset lisätietoineen (nimi, kuvaus). Näitä ei tule koulutuksen mukana GET /api/profiili/koulutukset -rajapinnasta.
Tallennus:
kategorian muokkaukseen PATCH /api/profiili/kategoria/id
koulutuksen muokkaukseen PATCH /api/profiili/koulutus/id, mukana osaamisten päivitys

https://jira.eduuni.fi/browse/OPHJOD-486
