### PR TITLE
OPHJOD-538: Refactor profiili API (part 1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ repositories {
 ext {
   spotbugsVersion = "4.8.6"
   set("flyway.version", "10.15.0")
+  set("lombok.version", "1.18.34")
 }
 
 dependencies {
@@ -52,7 +53,7 @@ dependencies {
   implementation 'io.micrometer:micrometer-registry-cloudwatch2'
   implementation 'io.zipkin.aws:brave-propagation-aws'
 
-  implementation platform('software.amazon.awssdk:bom:2.25.58')
+  implementation platform('software.amazon.awssdk:bom:2.26.15')
   implementation 'software.amazon.awssdk:auth'
   implementation 'software.amazon.awssdk:rds'
   implementation 'software.amazon.awssdk:sagemakerruntime'
@@ -67,8 +68,8 @@ dependencies {
   implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 
   // OpenAPI API description and Swagger UI
-  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.5.0'
-  developmentOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.6.0'
+  developmentOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
   compileOnly 'org.projectlombok:lombok'
   developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/OsaamisetEhdotusController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/OsaamisetEhdotusController.java
@@ -42,5 +42,5 @@ class OsaamisetEhdotusController {
     return ResponseEntity.ok(service.createEhdotus(taidot.kuvaus().value()));
   }
 
-  public record Taidot(@NotNull @Size(min = 10, max = 10_000) NormalizedString kuvaus) {}
+  public record Taidot(@NotNull @Size(min = 3, max = 10_000) NormalizedString kuvaus) {}
 }

--- a/src/main/java/fi/okm/jod/yksilo/controller/profiili/KoulutusController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/profiili/KoulutusController.java
@@ -14,6 +14,7 @@ import fi.okm.jod.yksilo.dto.profiili.KategoriaDto;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusDto;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusKategoriaDto;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusUpdateResultDto;
+import fi.okm.jod.yksilo.dto.validationgroup.Add;
 import fi.okm.jod.yksilo.service.profiili.KoulutusService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,97 +25,77 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/profiili")
+@RequestMapping("/api/profiili/koulutukset")
 @RequiredArgsConstructor
 @Tag(name = "profiili")
 class KoulutusController {
   private final KoulutusService service;
 
-  @GetMapping(path = "/koulutukset")
+  @GetMapping
   @ResponseStatus(HttpStatus.OK)
-  @Operation(
-      summary = "Get all koulutukset and kategoriat of the user",
-      description =
-          """
-              This endpoint can be used to get all koulutukset and kategoriat of the user.
-              """)
+  @Operation(summary = "Get all koulutukset and kategoriat of the user")
   List<KoulutusKategoriaDto> find(@AuthenticationPrincipal JodUser user) {
     return service.findAll(user);
   }
 
-  @PostMapping(path = "/koulutukset")
+  @PostMapping
   @ResponseStatus(HttpStatus.OK)
   @Operation(
-      summary = "Adds a new set of koulutus and its associated kategoria",
-      description =
-          """
-              This endpoint can be used to add a new Kategoria and its associated Koulutus.
-              If kategoria is not present koulutus will be added without kategoria.
-              """)
-  KoulutusUpdateResultDto create(
-      @RequestBody @Valid KoulutusKategoriaDto dto, @AuthenticationPrincipal JodUser user) {
-    return service.create(user, dto.kategoria(), dto.koulutukset());
+      summary =
+          "Creates a set of Koulutus associated with an optional Kategoria, creating the Kategoria if necessary")
+  KoulutusUpdateResultDto add(
+      @RequestBody @Validated(Add.class) KoulutusKategoriaDto dto,
+      @AuthenticationPrincipal JodUser user) {
+    return service.upsert(user, dto.kategoria(), dto.koulutukset());
   }
 
-  @PatchMapping(path = "/koulutukset/{id}")
+  @PutMapping
   @ResponseStatus(HttpStatus.OK)
   @Operation(
-      summary = "Updates the koulutus by id",
-      description =
-          """
-              This endpoint can be used to update Koulutus.
-              """)
-  KoulutusUpdateResultDto updateKoulutus(
+      summary = "Updates a set of Koulutus",
+      description = "If an existing Koulutus in a Kategoria is omitted, it will be removed.")
+  KoulutusUpdateResultDto update(
+      @RequestBody @Valid KoulutusKategoriaDto dto, @AuthenticationPrincipal JodUser user) {
+    return service.merge(user, dto.kategoria(), dto.koulutukset());
+  }
+
+  @DeleteMapping
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  void deleteAll(@RequestParam Set<UUID> ids, @AuthenticationPrincipal JodUser user) {
+    service.delete(user, ids);
+  }
+
+  @PutMapping(path = "/{id}")
+  @ResponseStatus(HttpStatus.OK)
+  void updateKoulutus(
       @PathVariable UUID id,
       @RequestBody @Valid KoulutusDto dto,
       @AuthenticationPrincipal JodUser user) {
     if (dto.id() == null || !id.equals(dto.id())) {
       throw new IllegalArgumentException("Invalid identifier");
     }
-    return service.update(user, dto);
   }
 
-  @PatchMapping(path = "/kategoriat/{id}")
+  @GetMapping("/{id}")
   @ResponseStatus(HttpStatus.OK)
-  @Operation(
-      summary = "Updates a Kategoria by id",
-      description =
-          """
-              This endpoint can be used to update the kagoria by id.
-              """)
-  KoulutusUpdateResultDto updateKategoria(
-      @PathVariable UUID id,
-      @RequestBody @Valid KategoriaDto dto,
-      @AuthenticationPrincipal JodUser user) {
-    if (dto.id() == null || !id.equals(dto.id())) {
-      throw new IllegalArgumentException("Invalid identifier");
-    }
-    return service.update(user, dto);
-  }
-
-  @GetMapping("/koulutukset/{id}")
-  @ResponseStatus(HttpStatus.OK)
-  KoulutusKategoriaDto get(@PathVariable UUID id, @AuthenticationPrincipal JodUser user) {
+  KoulutusDto get(@PathVariable UUID id, @AuthenticationPrincipal JodUser user) {
     return service.find(user, id);
   }
 
-  @DeleteMapping("/koulutukset/{id}")
-  @Operation(
-      summary = "Delete the koulutus by id",
-      description = """
-      This endpoint can be used to delete the koulutus by id
-      """)
+  @DeleteMapping("/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   void delete(@PathVariable UUID id, @AuthenticationPrincipal JodUser user) {
     service.delete(user, Set.of(id));
@@ -123,5 +104,17 @@ class KoulutusController {
   @GetMapping("/kategoriat")
   List<KategoriaDto> getKategoriat(@AuthenticationPrincipal JodUser user) {
     return service.getKategoriat(user);
+  }
+
+  @PutMapping(path = "/kategoriat/{id}")
+  @ResponseStatus(HttpStatus.OK)
+  void updateKategoria(
+      @PathVariable UUID id,
+      @RequestBody @Valid KategoriaDto dto,
+      @AuthenticationPrincipal JodUser user) {
+    if (dto.id() == null || !id.equals(dto.id())) {
+      throw new IllegalArgumentException("Invalid identifier");
+    }
+    service.updateKategoria(user, dto);
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/controller/profiili/KoulutusController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/profiili/KoulutusController.java
@@ -87,6 +87,7 @@ class KoulutusController {
     if (dto.id() == null || !id.equals(dto.id())) {
       throw new IllegalArgumentException("Invalid identifier");
     }
+    service.update(user, dto);
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/fi/okm/jod/yksilo/controller/profiili/KoulutusKokonaisuusController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/profiili/KoulutusKokonaisuusController.java
@@ -38,17 +38,18 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/profiili/koulutukset")
+@RequestMapping("/api/profiili/koulutuskokonaisuudet")
 @RequiredArgsConstructor
-@Tag(name = "profiili")
-class KoulutusController {
+@Tag(name = "profiili-koulutuskokonaisuudet")
+class KoulutusKokonaisuusController {
   private final KoulutusService service;
 
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
   @Operation(summary = "Get all koulutukset and kategoriat of the user")
-  List<KoulutusKategoriaDto> find(@AuthenticationPrincipal JodUser user) {
-    return service.findAll(user);
+  List<KoulutusKategoriaDto> findAll(
+      @AuthenticationPrincipal JodUser user, @RequestParam(required = false) UUID kategoria) {
+    return kategoria == null ? service.findAll(user) : service.findAll(user, kategoria);
   }
 
   @PostMapping
@@ -72,13 +73,16 @@ class KoulutusController {
     return service.merge(user, dto.kategoria(), dto.koulutukset());
   }
 
-  @DeleteMapping
+  @DeleteMapping("/koulutukset")
+  @Operation(
+      summary = "Deletes one or more Koulutus by ID",
+      description = "Possible resulting empty Kategoria are alse removed.")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  void deleteAll(@RequestParam Set<UUID> ids, @AuthenticationPrincipal JodUser user) {
-    service.delete(user, ids);
+  void deleteKoulutukset(@RequestParam Set<UUID> ids, @AuthenticationPrincipal JodUser user) {
+    service.deleteKoulutukset(user, ids);
   }
 
-  @PutMapping(path = "/{id}")
+  @PutMapping(path = "/koulutukset/{id}")
   @ResponseStatus(HttpStatus.OK)
   void updateKoulutus(
       @PathVariable UUID id,
@@ -90,16 +94,16 @@ class KoulutusController {
     service.update(user, dto);
   }
 
-  @GetMapping("/{id}")
+  @GetMapping("/koulutukset/{id}")
   @ResponseStatus(HttpStatus.OK)
-  KoulutusDto get(@PathVariable UUID id, @AuthenticationPrincipal JodUser user) {
-    return service.find(user, id);
+  KoulutusDto getKoulutus(@PathVariable UUID id, @AuthenticationPrincipal JodUser user) {
+    return service.getKoulutus(user, id);
   }
 
-  @DeleteMapping("/{id}")
+  @DeleteMapping("/koulutukset/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  void delete(@PathVariable UUID id, @AuthenticationPrincipal JodUser user) {
-    service.delete(user, Set.of(id));
+  void deleteKoulutus(@PathVariable UUID id, @AuthenticationPrincipal JodUser user) {
+    service.deleteKoulutukset(user, Set.of(id));
   }
 
   @GetMapping("/kategoriat")

--- a/src/main/java/fi/okm/jod/yksilo/controller/profiili/YksilonOsaaminenController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/profiili/YksilonOsaaminenController.java
@@ -48,8 +48,8 @@ class YksilonOsaaminenController {
   List<YksilonOsaaminenDto> find(
       @AuthenticationPrincipal JodUser user,
       @RequestParam(required = false) OsaamisenLahdeTyyppi tyyppi,
-      @RequestParam(required = false) UUID id) {
-    return service.findAll(user, tyyppi, id);
+      @RequestParam(required = false) UUID lahdeId) {
+    return service.findAll(user, tyyppi, lahdeId);
   }
 
   @PostMapping

--- a/src/main/java/fi/okm/jod/yksilo/domain/LocalizedString.java
+++ b/src/main/java/fi/okm/jod/yksilo/domain/LocalizedString.java
@@ -48,6 +48,7 @@ public final class LocalizedString {
         };
   }
 
+  @Schema(hidden = true)
   public String get(Kieli kieli) {
     return values.get(requireNonNull(kieli));
   }
@@ -57,11 +58,16 @@ public final class LocalizedString {
     return values;
   }
 
+  @Schema(hidden = true)
   public boolean isEmpty() {
     return values.isEmpty();
   }
 
-  // for JSON serialization, map empty to null
+  /**
+   * For JSON serialization, maps empty to null
+   *
+   * @see fi.okm.jod.yksilo.config.mapping.LocalizedStringMixin
+   */
   public Map<Kieli, String> toJson() {
     return values.isEmpty() ? null : values;
   }

--- a/src/main/java/fi/okm/jod/yksilo/dto/YksiloCsrfDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/YksiloCsrfDto.java
@@ -9,7 +9,11 @@
 
 package fi.okm.jod.yksilo.dto;
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
 
-public record YksiloCsrfDto(@JsonUnwrapped YksiloDto yksilo, @NotNull CsrfTokenDto csrf) {}
+public record YksiloCsrfDto(UUID kuva, @NotNull CsrfTokenDto csrf) {
+  public YksiloCsrfDto(YksiloDto yksilo, CsrfTokenDto csrf) {
+    this(yksilo.kuva(), csrf);
+  }
+}

--- a/src/main/java/fi/okm/jod/yksilo/entity/Koulutus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Koulutus.java
@@ -14,6 +14,8 @@ import static java.util.Objects.requireNonNull;
 
 import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.domain.LocalizedString;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -44,15 +46,16 @@ import org.hibernate.annotations.BatchSize;
 @Entity
 @Getter
 @Table(indexes = {@Index(columnList = "yksilo_id")})
+@Access(AccessType.FIELD)
 public non-sealed class Koulutus implements OsaamisenLahde {
   @GeneratedValue @Id private UUID id;
 
   @Setter private LocalDate alkuPvm;
   @Setter private LocalDate loppuPvm;
 
-  @NotNull
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(updatable = false, nullable = false)
+  @NotNull
   private Yksilo yksilo;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -92,6 +95,13 @@ public non-sealed class Koulutus implements OsaamisenLahde {
 
   public void setKuvaus(LocalizedString kuvaus) {
     merge(kuvaus, kaannos, Kaannos::new, Kaannos::setKuvaus);
+  }
+
+  @NotNull
+  public Yksilo getYksilo() {
+    // workaround to suppress Hibernate compile-time tooling 6.5.2.Final
+    // warning: member 'getYksilo' of 'Koulutus' is not annotated '@ManyToOne'
+    return yksilo;
   }
 
   @Embeddable

--- a/src/main/java/fi/okm/jod/yksilo/entity/KoulutusKategoria.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/KoulutusKategoria.java
@@ -84,6 +84,7 @@ public class KoulutusKategoria {
   @Embeddable
   @Data
   static class Kaannos implements Translation {
+    @NotNull
     @Basic(optional = false)
     String nimi;
 

--- a/src/main/java/fi/okm/jod/yksilo/errorhandler/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/okm/jod/yksilo/errorhandler/ExceptionHandlerAdvice.java
@@ -102,7 +102,7 @@ class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
   protected ResponseEntity<Object> handleServiceException(
       ServiceValidationException ex, WebRequest request) {
     var info = errorInfo.of(ErrorCode.VALIDATION_FAILURE, List.of(ex.getMessage()));
-    return handleExceptionInternal(ex, info, new HttpHeaders(), HttpStatus.NOT_FOUND, request);
+    return handleExceptionInternal(ex, info, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
   }
 
   @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/fi/okm/jod/yksilo/service/ehdotus/OsaamisetEhdotusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/ehdotus/OsaamisetEhdotusService.java
@@ -77,7 +77,7 @@ public class OsaamisetEhdotusService {
 
     log.info("Creating a suggestion for osaamiset");
     try {
-      var result = restClient.post().body(new Input(kuvaus, 13, 1)).retrieve().body(Result.class);
+      var result = restClient.post().body(new Input(kuvaus, 37, 1)).retrieve().body(Result.class);
 
       if (result == null || result.skills() == null) {
         return List.of();

--- a/src/main/java/fi/okm/jod/yksilo/service/ehdotus/OsaamisetEhdotusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/ehdotus/OsaamisetEhdotusService.java
@@ -33,6 +33,8 @@ import org.springframework.web.client.RestClientException;
 @Transactional(readOnly = true)
 public class OsaamisetEhdotusService {
 
+  public static final int MAX_NUMBER_OF_SKILLS = 37;
+  public static final int MAX_NUMBER_OF_OCCUPATIONS = 1;
   private final RestClient restClient;
   private final OsaaminenRepository osaamiset;
 
@@ -77,7 +79,12 @@ public class OsaamisetEhdotusService {
 
     log.info("Creating a suggestion for osaamiset");
     try {
-      var result = restClient.post().body(new Input(kuvaus, 37, 1)).retrieve().body(Result.class);
+      var result =
+          restClient
+              .post()
+              .body(new Input(kuvaus, MAX_NUMBER_OF_SKILLS, MAX_NUMBER_OF_OCCUPATIONS))
+              .retrieve()
+              .body(Result.class);
 
       if (result == null || result.skills() == null) {
         return List.of();

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/KoulutusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/KoulutusService.java
@@ -88,14 +88,14 @@ public class KoulutusService {
     return groupByKategoria(koulutukset.findByYksilo(yksilo, sort));
   }
 
-  public KoulutusDto find(JodUser user, UUID id) {
+  public KoulutusDto getKoulutus(JodUser user, UUID koulutusId) {
     return koulutukset
-        .findByYksiloIdAndId(user.getId(), id)
+        .findByYksiloIdAndId(user.getId(), koulutusId)
         .map(Mapper::mapKoulutus)
         .orElseThrow(KoulutusService::notFound);
   }
 
-  public KategoriaDto findKategoriaById(JodUser user, UUID kategoriaId) {
+  public KategoriaDto getKategoria(JodUser user, UUID kategoriaId) {
     return kategoriat
         .findByYksiloAndId(yksilot.getReferenceById(user.getId()), kategoriaId)
         .map(Mapper::mapKategoria)
@@ -103,7 +103,6 @@ public class KoulutusService {
   }
 
   public List<KoulutusKategoriaDto> findAll(JodUser user, UUID kategoriaId) {
-
     final Yksilo yksilo = yksilot.getReferenceById(user.getId());
     var sort = Sort.by(Koulutus_.KATEGORIA, Koulutus_.ALKU_PVM, Koulutus_.ID);
     return groupByKategoria(koulutukset.findByYksiloAndKategoriaId(yksilo, kategoriaId, sort));
@@ -178,7 +177,7 @@ public class KoulutusService {
     return new KoulutusUpdateResultDto(kategoria == null ? null : kategoria.getId(), touched);
   }
 
-  public void delete(JodUser user, Set<UUID> ids) {
+  public void deleteKoulutukset(JodUser user, Set<UUID> ids) {
     var yksilo = yksilot.getReferenceById(user.getId());
     var entities = koulutukset.findByYksiloAndIdIn(yksilo, ids);
 

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/KoulutusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/KoulutusService.java
@@ -10,6 +10,7 @@
 package fi.okm.jod.yksilo.service.profiili;
 
 import static fi.okm.jod.yksilo.service.profiili.Mapper.cachingMapper;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toSet;
@@ -118,6 +119,7 @@ public class KoulutusService {
     return merge(user, kategoriaDto, dtos, true);
   }
 
+  @SuppressWarnings("java:S3776")
   private KoulutusUpdateResultDto merge(
       JodUser user, KategoriaDto kategoriaDto, Set<KoulutusDto> dtos, boolean partial) {
 
@@ -247,6 +249,9 @@ public class KoulutusService {
   }
 
   public void updateKategoria(JodUser user, KategoriaDto dto) {
+    requireNonNull(dto);
+    requireNonNull(dto.id());
+
     var kategoria = resolve(yksilot.getReferenceById(user.getId()), dto);
     kategoria.setNimi(dto.nimi());
     kategoria.setKuvaus(dto.kuvaus());

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/TyopaikkaService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/TyopaikkaService.java
@@ -15,6 +15,7 @@ import fi.okm.jod.yksilo.entity.Tyopaikka;
 import fi.okm.jod.yksilo.repository.TyopaikkaRepository;
 import fi.okm.jod.yksilo.repository.YksiloRepository;
 import fi.okm.jod.yksilo.service.NotFoundException;
+import fi.okm.jod.yksilo.service.ServiceException;
 import fi.okm.jod.yksilo.service.ServiceValidationException;
 import fi.okm.jod.yksilo.validation.Limits;
 import java.util.HashSet;
@@ -42,14 +43,12 @@ public class TyopaikkaService {
     return tyopaikat
         .findByYksiloIdAndId(user.getId(), id)
         .map(Mapper::mapTyopaikka)
-        .orElseThrow(() -> new NotFoundException("Työpaikka not found"));
+        .orElseThrow(TyopaikkaService::notFound);
   }
 
   public void delete(JodUser user, UUID id) {
     var tyopaikka =
-        tyopaikat
-            .findByYksiloIdAndId(user.getId(), id)
-            .orElseThrow(() -> new NotFoundException("Työpaikka not found"));
+        tyopaikat.findByYksiloIdAndId(user.getId(), id).orElseThrow(TyopaikkaService::notFound);
     for (var toimenkuva : tyopaikka.getToimenkuvat()) {
       toimenkuvaService.delete(toimenkuva);
     }
@@ -60,7 +59,7 @@ public class TyopaikkaService {
     var entity =
         tyopaikat
             .findByYksiloIdAndId(user.getId(), dto.id())
-            .orElseThrow(() -> new NotFoundException("Työpaikka not found"));
+            .orElseThrow(TyopaikkaService::notFound);
     entity.setNimi(dto.nimi());
     tyopaikat.save(entity);
     var toimenkuvat = dto.toimenkuvat();
@@ -100,5 +99,9 @@ public class TyopaikkaService {
     }
 
     return entity.getId();
+  }
+
+  private static ServiceException notFound() {
+    return new NotFoundException("Työpaikka not found");
   }
 }

--- a/src/main/resources/data-import.sql
+++ b/src/main/resources/data-import.sql
@@ -2,6 +2,8 @@
 -- This is a temporary solution until database migrations are implemented
 
 -- Osaaminen (ESCO 1.2)
+TRUNCATE osaaminen CASCADE;
+
 CREATE SEQUENCE IF NOT EXISTS osaaminen_seq;
 SELECT setval('osaaminen_seq', (SELECT COALESCE(MAX(id), 1) FROM osaaminen));
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,27 +1,33 @@
 -- TEST DATA FOR EARLY DEVELOPMENT
 INSERT INTO yksilo (id, tunnus)
-VALUES ('495ae98d-593d-4a0f-8d36-daf5cceafdfd', 'user1');
-INSERT INTO yksilo (id, tunnus)
-VALUES ('e5ff74e0-5eaa-466d-8989-326536c19763', 'user2');
-INSERT INTO yksilo (id, tunnus)
-VALUES ('9b110e0c-297f-4b0a-8cf1-0c0a812b760b', 'user3');
+VALUES ('495ae98d-593d-4a0f-8d36-daf5cceafdfd', 'user1'),
+       ('e5ff74e0-5eaa-466d-8989-326536c19763', 'user2'),
+       ('9b110e0c-297f-4b0a-8cf1-0c0a812b760b', 'user3')
+ON CONFLICT DO NOTHING;
 
 INSERT INTO osaaminen(id, uri)
 VALUES (1, 'urn:osaaminen1'),
        (2, 'urn:osaaminen2'),
-       (3, 'urn:osaaminen3');
+       (3, 'urn:osaaminen3')
+ON CONFLICT DO NOTHING;
 
 INSERT INTO osaaminen_kaannos(osaaminen_id, kaannos_key, nimi, kuvaus)
 VALUES (1, 'FI', 'Osaaminen 1', 'Kuvaus 1'),
        (2, 'FI', 'Osaaminen 2', 'Kuvaus 2'),
-       (3, 'FI', 'Osaaminen 3', 'Kuvaus 3');
+       (3, 'FI', 'Osaaminen 3', 'Kuvaus 3')
+ON CONFLICT DO NOTHING;
 
 INSERT INTO tyomahdollisuus(id)
 VALUES ('495ae98d-593d-4a0f-8d36-daf5cceafdfd'),
        ('e5ff74e0-5eaa-466d-8989-326536c19763'),
-       ('9b110e0c-297f-4b0a-8cf1-0c0a812b760b');
+       ('9b110e0c-297f-4b0a-8cf1-0c0a812b760b')
+ON CONFLICT DO NOTHING;
 
 INSERT INTO tyomahdollisuus_kaannos(tyomahdollisuus_id, kaannos_key, otsikko, tiivistelma)
-VALUES ('495ae98d-593d-4a0f-8d36-daf5cceafdfd', 'FI', 'Laborantti', 'Laborantti analysoi näytteitä.'),
-       ('e5ff74e0-5eaa-466d-8989-326536c19763', 'FI', 'Tarjoilija', 'Tarjoilija tarjoilee asiakkaille ruokaa ja juomaa.'),
-       ('9b110e0c-297f-4b0a-8cf1-0c0a812b760b', 'FI', 'Kuorma-autonkuljettaja', 'Kuorma-autonkuljettaja kuljettaa tavaraa.');
+VALUES ('495ae98d-593d-4a0f-8d36-daf5cceafdfd', 'FI', 'Laborantti',
+        'Laborantti analysoi näytteitä.'),
+       ('e5ff74e0-5eaa-466d-8989-326536c19763', 'FI', 'Tarjoilija',
+        'Tarjoilija tarjoilee asiakkaille ruokaa ja juomaa.'),
+       ('9b110e0c-297f-4b0a-8cf1-0c0a812b760b', 'FI', 'Kuorma-autonkuljettaja',
+        'Kuorma-autonkuljettaja kuljettaa tavaraa.')
+ON CONFLICT DO NOTHING;

--- a/src/test/java/fi/okm/jod/yksilo/service/KoulutusServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/KoulutusServiceTest.java
@@ -85,7 +85,7 @@ class KoulutusServiceTest extends AbstractServiceTest {
     assertDoesNotThrow(
         () -> {
           var user = TestJodUser.of(TEST_USER_1_UUID.toString());
-          var oldKoulutus = service.find(user, TEST_KOULUTUS_1_UUID);
+          var oldKoulutus = service.getKoulutus(user, TEST_KOULUTUS_1_UUID);
           var newOsaamiset =
               Set.of(
                   URI.create("urn:osaaminen1"),
@@ -110,7 +110,7 @@ class KoulutusServiceTest extends AbstractServiceTest {
           service.update(user, koulutusToPatch);
           entityManager.flush();
 
-          var updatedKoulutus = service.find(user, TEST_KOULUTUS_1_UUID);
+          var updatedKoulutus = service.getKoulutus(user, TEST_KOULUTUS_1_UUID);
           assertNotNull(updatedKoulutus);
 
           assertEquals("uusi nimi", updatedKoulutus.nimi().get(Kieli.FI));
@@ -150,7 +150,7 @@ class KoulutusServiceTest extends AbstractServiceTest {
           service.updateKategoria(user, kategoriaToPatch);
           entityManager.flush();
 
-          var updatedKategoria = service.findKategoriaById(user, TEST_KATEGORIA_1_UUID);
+          var updatedKategoria = service.getKategoria(user, TEST_KATEGORIA_1_UUID);
           assertNotNull(updatedKategoria);
 
           assertEquals("uusi nimi", updatedKategoria.nimi().get(Kieli.FI));

--- a/src/test/java/fi/okm/jod/yksilo/service/TyopaikkaServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/TyopaikkaServiceTest.java
@@ -13,10 +13,16 @@ import static fi.okm.jod.yksilo.testutil.LocalizedStrings.ls;
 import static org.junit.jupiter.api.Assertions.*;
 
 import fi.okm.jod.yksilo.domain.Kieli;
+import fi.okm.jod.yksilo.dto.profiili.ToimenkuvaDto;
 import fi.okm.jod.yksilo.dto.profiili.TyopaikkaDto;
+import fi.okm.jod.yksilo.repository.ToimenkuvaRepository;
+import fi.okm.jod.yksilo.repository.YksilonOsaaminenRepository;
 import fi.okm.jod.yksilo.service.profiili.ToimenkuvaService;
 import fi.okm.jod.yksilo.service.profiili.TyopaikkaService;
 import fi.okm.jod.yksilo.service.profiili.YksilonOsaaminenService;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -27,6 +33,8 @@ import org.springframework.test.context.jdbc.Sql;
 class TyopaikkaServiceTest extends AbstractServiceTest {
 
   @Autowired TyopaikkaService service;
+  @Autowired ToimenkuvaRepository toimenkuvat;
+  @Autowired YksilonOsaaminenRepository osaaminen;
 
   @Test
   void shouldAddTyopaikka() {
@@ -43,6 +51,80 @@ class TyopaikkaServiceTest extends AbstractServiceTest {
           var result = service.findAll(user);
           assertEquals(1, result.size());
           assertEquals(updatedNimi, result.getFirst().nimi());
+        });
+  }
+
+  @Test
+  void shouldCreateAndRemoveToimenkuvaOnUpdate() {
+    var id =
+        service.add(
+            user,
+            new TyopaikkaDto(
+                null,
+                ls(Kieli.FI, "nimi"),
+                Set.of(
+                    new ToimenkuvaDto(
+                        null,
+                        ls(Kieli.FI, "nimi"),
+                        ls(Kieli.FI, "kuvaus"),
+                        LocalDate.now(),
+                        null,
+                        Set.of(URI.create("urn:osaaminen1"))))));
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var tyopaikka = service.find(user, id);
+    var toimenkuvaId = tyopaikka.toimenkuvat().iterator().next().id();
+
+    entityManager.clear();
+
+    var updatedTyopaikka =
+        new TyopaikkaDto(
+            tyopaikka.id(),
+            tyopaikka.nimi(),
+            Set.of(
+                new ToimenkuvaDto(
+                    null,
+                    ls(Kieli.FI, "nimi 2"),
+                    ls(Kieli.FI, "kuvaus 2"),
+                    LocalDate.now(),
+                    null,
+                    Set.of(URI.create("urn:osaaminen1")))));
+    service.update(user, updatedTyopaikka);
+    entityManager.flush();
+    updatedTyopaikka = service.find(user, id);
+
+    assertEquals(1, updatedTyopaikka.toimenkuvat().size());
+    assertTrue(toimenkuvat.findBy(user, id, toimenkuvaId).isEmpty());
+  }
+
+  @Test
+  void shouldRemoveTyopaikka() {
+    assertDoesNotThrow(
+        () -> {
+          var id =
+              service.add(
+                  user,
+                  new TyopaikkaDto(
+                      null,
+                      ls(Kieli.FI, "nimi"),
+                      Set.of(
+                          new ToimenkuvaDto[] {
+                            new ToimenkuvaDto(
+                                null,
+                                ls(Kieli.FI, "nimi"),
+                                ls(Kieli.FI, "kuvaus"),
+                                LocalDate.now(),
+                                null,
+                                Set.of(URI.create("urn:osaaminen1")))
+                          })));
+
+          entityManager.flush();
+          entityManager.clear();
+
+          service.delete(user, id);
+          entityManager.flush();
         });
   }
 }

--- a/src/test/java/fi/okm/jod/yksilo/testutil/LocalizedStrings.java
+++ b/src/test/java/fi/okm/jod/yksilo/testutil/LocalizedStrings.java
@@ -11,10 +11,7 @@ package fi.okm.jod.yksilo.testutil;
 
 import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.domain.LocalizedString;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
-import org.springframework.data.util.Pair;
 
 public interface LocalizedStrings {
   static LocalizedString ls(String s) {
@@ -25,13 +22,11 @@ public interface LocalizedStrings {
     return new LocalizedString(Map.of(k, s));
   }
 
-  @SafeVarargs
-  static LocalizedString ls(Pair<Kieli, String>... values) {
-    return new LocalizedString(
-        Arrays.stream(values).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)));
-  }
-
   static LocalizedString ls(Kieli k, String s, Kieli k2, String s2) {
     return new LocalizedString(Map.of(k, s, k2, s2));
+  }
+
+  static LocalizedString ls(Kieli k, String s, Kieli k2, String s2, Kieli k3, String s3) {
+    return new LocalizedString(Map.of(k, s, k2, s2, k3, s3));
   }
 }


### PR DESCRIPTION
## Description
A first step in refactoring the profiili API. Adds missing operations to Koulutus and Tyopaikka. Update now suppors adding new Toimenkuva/Koulutus, and removes Toimenkuva/Koulutus if necessary.

see also https://github.com/Opetushallitus/jod-yksilo-ui/pull/92

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-538

