### PR TITLE
OPHJOD-580: Fix API returns null properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           cat <<EOF >>$GITHUB_STEP_SUMMARY
           Created image:
-          ```${{ steps.docker-meta.outputs.tags }}```
+              ${{ steps.docker-meta.outputs.tags }}
           EOF
 
   deploy-dev:
@@ -116,7 +116,9 @@ jobs:
 
   deploy-test:
     if: github.ref == 'refs/heads/main'
-    needs: deploy-dev
+    needs:
+      - package
+      - deploy-dev
     uses: ./.github/workflows/deploy.yml
     permissions:
       id-token: write

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@ plugins {
   id 'jacoco'
 
   id 'org.springframework.boot' version '3.3.1'
-  id 'io.spring.dependency-management' version '1.1.5'
+  id 'io.spring.dependency-management' version '1.1.6'
 
   id 'checkstyle'
   id "com.diffplug.spotless" version "6.25.0"
-  id "com.github.spotbugs" version "6.0.18"
-  id "org.sonarqube" version "5.0.0.4638"
+  id "com.github.spotbugs" version "6.0.19"
+  id "org.sonarqube" version "5.1.0.4882"
   id 'org.springdoc.openapi-gradle-plugin' version '1.9.0'
 
   id "io.snyk.gradle.plugin.snykplugin" version "0.6.1"
@@ -53,7 +53,7 @@ dependencies {
   implementation 'io.micrometer:micrometer-registry-cloudwatch2'
   implementation 'io.zipkin.aws:brave-propagation-aws'
 
-  implementation platform('software.amazon.awssdk:bom:2.26.15')
+  implementation platform('software.amazon.awssdk:bom:2.26.20')
   implementation 'software.amazon.awssdk:auth'
   implementation 'software.amazon.awssdk:rds'
   implementation 'software.amazon.awssdk:sagemakerruntime'

--- a/src/main/java/fi/okm/jod/yksilo/config/mapping/LocalizedStringMixin.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mapping/LocalizedStringMixin.java
@@ -17,5 +17,5 @@ import java.util.Map;
 // is in the actual class
 interface LocalizedStringMixin {
   @JsonValue
-  Map<Kieli, String> toJson();
+  Map<Kieli, String> asMap();
 }

--- a/src/main/java/fi/okm/jod/yksilo/config/mapping/MappingConfig.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mapping/MappingConfig.java
@@ -9,6 +9,7 @@
 
 package fi.okm.jod.yksilo.config.mapping;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import fi.okm.jod.yksilo.domain.LocalizedString;
@@ -25,6 +26,7 @@ public class MappingConfig {
             .featuresToEnable(
                 SerializationFeature.WRITE_ENUMS_USING_TO_STRING,
                 MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+            .serializationInclusion(JsonInclude.Include.NON_NULL)
             .mixIn(LocalizedString.class, LocalizedStringMixin.class);
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/dto/profiili/KategoriaDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/profiili/KategoriaDto.java
@@ -26,6 +26,6 @@ public record KategoriaDto(
   @JsonIgnore
   @AssertTrue(message = "nimi is required")
   public boolean isValid() {
-    return id != null || nimi != null && !nimi.isEmpty();
+    return id != null || nimi != null;
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/dto/profiili/KoulutusDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/profiili/KoulutusDto.java
@@ -13,6 +13,7 @@ import fi.okm.jod.yksilo.domain.LocalizedString;
 import fi.okm.jod.yksilo.dto.validationgroup.Add;
 import fi.okm.jod.yksilo.validation.PrintableString;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Size;
 import java.net.URI;
@@ -24,7 +25,7 @@ public record KoulutusDto(
     @Null(groups = Add.class) UUID id,
     @NotEmpty @Size(max = 200) @PrintableString LocalizedString nimi,
     @Size(max = 10000) @PrintableString LocalizedString kuvaus,
-    LocalDate alkuPvm,
+    @NotNull LocalDate alkuPvm,
     LocalDate loppuPvm,
     Set<URI> osaamiset)
     implements ValidInterval {}

--- a/src/main/java/fi/okm/jod/yksilo/entity/Koulutus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Koulutus.java
@@ -82,11 +82,11 @@ public non-sealed class Koulutus implements OsaamisenLahde {
   }
 
   public LocalizedString getNimi() {
-    return new LocalizedString(kaannos, Kaannos::getNimi);
+    return LocalizedString.of(kaannos, Kaannos::getNimi);
   }
 
   public LocalizedString getKuvaus() {
-    return new LocalizedString(kaannos, Kaannos::getKuvaus);
+    return LocalizedString.of(kaannos, Kaannos::getKuvaus);
   }
 
   public void setNimi(LocalizedString nimi) {

--- a/src/main/java/fi/okm/jod/yksilo/entity/KoulutusKategoria.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/KoulutusKategoria.java
@@ -66,11 +66,11 @@ public class KoulutusKategoria {
   }
 
   public LocalizedString getNimi() {
-    return new LocalizedString(kaannos, Kaannos::getNimi);
+    return LocalizedString.of(kaannos, Kaannos::getNimi);
   }
 
   public LocalizedString getKuvaus() {
-    return new LocalizedString(kaannos, Kaannos::getKuvaus);
+    return LocalizedString.of(kaannos, Kaannos::getKuvaus);
   }
 
   public void setNimi(LocalizedString nimi) {

--- a/src/main/java/fi/okm/jod/yksilo/entity/Osaaminen.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Osaaminen.java
@@ -43,10 +43,10 @@ public class Osaaminen {
       @Column(columnDefinition = "TEXT") String kuvaus) {}
 
   public LocalizedString getNimi() {
-    return new LocalizedString(kaannos, Kaannos::nimi);
+    return LocalizedString.of(kaannos, Kaannos::nimi);
   }
 
   public LocalizedString getKuvaus() {
-    return new LocalizedString(kaannos, Kaannos::kuvaus);
+    return LocalizedString.of(kaannos, Kaannos::kuvaus);
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/entity/Patevyys.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Patevyys.java
@@ -74,7 +74,7 @@ public non-sealed class Patevyys implements OsaamisenLahde {
   }
 
   public LocalizedString getNimi() {
-    return new LocalizedString(kaannos, Kaannos::getNimi);
+    return LocalizedString.of(kaannos, Kaannos::getNimi);
   }
 
   public void setNimi(LocalizedString nimi) {

--- a/src/main/java/fi/okm/jod/yksilo/entity/Toimenkuva.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Toimenkuva.java
@@ -75,11 +75,11 @@ public non-sealed class Toimenkuva implements OsaamisenLahde {
   }
 
   public LocalizedString getNimi() {
-    return new LocalizedString(kaannos, Kaannos::getNimi);
+    return LocalizedString.of(kaannos, Kaannos::getNimi);
   }
 
   public LocalizedString getKuvaus() {
-    return new LocalizedString(kaannos, Kaannos::getKuvaus);
+    return LocalizedString.of(kaannos, Kaannos::getKuvaus);
   }
 
   public void setNimi(LocalizedString nimi) {

--- a/src/main/java/fi/okm/jod/yksilo/entity/Toiminto.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Toiminto.java
@@ -75,7 +75,7 @@ public class Toiminto {
   }
 
   public LocalizedString getNimi() {
-    return new LocalizedString(kaannos, Kaannos::nimi);
+    return LocalizedString.of(kaannos, Kaannos::nimi);
   }
 
   public void setNimi(LocalizedString nimi) {

--- a/src/main/java/fi/okm/jod/yksilo/entity/Tyomahdollisuus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Tyomahdollisuus.java
@@ -52,14 +52,14 @@ public class Tyomahdollisuus {
       @Column(columnDefinition = "TEXT") String kuvaus) {}
 
   public LocalizedString getOtsikko() {
-    return new LocalizedString(kaannos, Kaannos::otsikko);
+    return LocalizedString.of(kaannos, Kaannos::otsikko);
   }
 
   public LocalizedString getKuvaus() {
-    return new LocalizedString(kaannos, Kaannos::kuvaus);
+    return LocalizedString.of(kaannos, Kaannos::kuvaus);
   }
 
   public LocalizedString getTiivistelma() {
-    return new LocalizedString(kaannos, Kaannos::tiivistelma);
+    return LocalizedString.of(kaannos, Kaannos::tiivistelma);
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/entity/Tyopaikka.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Tyopaikka.java
@@ -81,7 +81,7 @@ public class Tyopaikka {
   }
 
   public LocalizedString getNimi() {
-    return new LocalizedString(kaannos, Kaannos::nimi);
+    return LocalizedString.of(kaannos, Kaannos::nimi);
   }
 
   public void setNimi(LocalizedString nimi) {

--- a/src/test/java/fi/okm/jod/yksilo/domain/LocalizedStringTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/domain/LocalizedStringTest.java
@@ -21,23 +21,23 @@ class LocalizedStringTest {
   void shouldCreateLocalizedString() {
     LocalizedString ls;
 
-    ls = new LocalizedString(Map.of(), Entity::s1);
-    assertTrue(ls.asMap().isEmpty());
+    ls = LocalizedString.of(Map.of(), Entity::s1);
+    assertNull(ls);
 
-    ls = new LocalizedString(Map.of(Kieli.EN, new Entity(null, null)), Entity::s1);
-    assertTrue(ls.asMap().isEmpty());
+    ls = LocalizedString.of(Map.of(Kieli.EN, new Entity(null, null)), Entity::s1);
+    assertNull(ls);
 
     var data1 = new HashMap<Kieli, Entity>();
     data1.put(null, null);
-    ls = new LocalizedString(data1, Entity::s1);
+    ls = LocalizedString.of(data1, Entity::s1);
     // special case, null value is ignored
-    assertTrue(ls.asMap().isEmpty());
+    assertNull(ls);
 
     var data2 = new HashMap<Kieli, Entity>();
     data2.put(null, new Entity("s1", null));
-    assertThrows(NullPointerException.class, () -> new LocalizedString(data2, Entity::s1));
+    assertThrows(NullPointerException.class, () -> LocalizedString.of(data2, Entity::s1));
 
-    ls = new LocalizedString(Map.of(Kieli.EN, new Entity("s1", null)), Entity::s1);
+    ls = LocalizedString.of(Map.of(Kieli.EN, new Entity("s1", null)), Entity::s1);
     assertEquals(Map.of(Kieli.EN, "s1"), ls.asMap());
     assertEquals(ls(Kieli.EN, "s1"), ls);
 
@@ -50,12 +50,14 @@ class LocalizedStringTest {
             Kieli.EN,
             new Entity("s5", null));
 
-    ls = new LocalizedString(data3, Entity::s1);
+    ls = LocalizedString.of(data3, Entity::s1);
+    assertNotNull(ls);
     final Map<Kieli, String> expected1 = Map.of(Kieli.FI, "s1", Kieli.EN, "s5");
     assertEquals(expected1, ls.asMap());
 
-    ls = new LocalizedString(data3, Entity::s2);
+    ls = LocalizedString.of(data3, Entity::s2);
     var expected2 = Map.of(Kieli.FI, "s2", Kieli.SV, "s4");
+    assertNotNull(ls);
     assertEquals(expected2, ls.asMap());
     assertNotEquals(new LocalizedString(expected1), ls);
     assertEquals(new LocalizedString(expected2), ls);


### PR DESCRIPTION
## Description
API should not return properties with null value since the API contract generally prohibits null. 

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-580