### PR TITLE
OPHJOD-212: Fix mock login

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/config/mocklogin/MockJodUserImpl.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mocklogin/MockJodUserImpl.java
@@ -7,12 +7,13 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
-package fi.okm.jod.yksilo.domain;
+package fi.okm.jod.yksilo.config.mocklogin;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import fi.okm.jod.yksilo.domain.JodUser;
 import java.io.Serial;
 import java.util.Collection;
 import java.util.Set;
@@ -83,7 +84,7 @@ public class MockJodUserImpl implements UserDetails, JodUser {
 
   @Override
   public String givenName() {
-    return "Mock " + id.hashCode();
+    return "Mock" + id.hashCode();
   }
 
   @Override

--- a/src/main/java/fi/okm/jod/yksilo/config/mocklogin/MockLoginConfig.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mocklogin/MockLoginConfig.java
@@ -7,10 +7,9 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
-package fi.okm.jod.yksilo.config;
+package fi.okm.jod.yksilo.config.mocklogin;
 
 import fi.okm.jod.yksilo.config.suomifi.Saml2LoginConfig;
-import fi.okm.jod.yksilo.domain.MockJodUserImpl;
 import fi.okm.jod.yksilo.entity.Yksilo;
 import fi.okm.jod.yksilo.repository.YksiloRepository;
 import java.util.UUID;
@@ -33,7 +32,7 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class MockLoginConfig {
 
-  /** Mock authentication using default form login. */
+  /** Mock authentication using form login. */
   @Bean
   SecurityFilterChain mockLoginFilterChain(HttpSecurity http) throws Exception {
     log.warn("WARNING: Using mock authentication.");
@@ -47,15 +46,15 @@ public class MockLoginConfig {
     var logoutSuccessHandler = new SimpleUrlLogoutSuccessHandler();
     logoutSuccessHandler.setRedirectStrategy(redirectStrategy);
 
-    return http.securityMatcher("/login", "/logout")
-        .formLogin(login -> login.successHandler(loginSuccessHandler))
+    return http.securityMatcher("/login/**", "/logout/**")
+        .formLogin(login -> login.successHandler(loginSuccessHandler).loginPage("/login"))
         .logout(logout -> logout.logoutSuccessHandler(logoutSuccessHandler))
         .headers(
             headers ->
                 headers.contentSecurityPolicy(
                     csp ->
                         csp.policyDirectives(
-                            "default-src 'self'; frame-ancestors 'none'; style-src 'self' https://maxcdn.bootstrapcdn.com https://getbootstrap.com;")))
+                            "default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline';")))
         .build();
   }
 

--- a/src/main/java/fi/okm/jod/yksilo/config/mocklogin/MockLoginController.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mocklogin/MockLoginController.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.config.mocklogin;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ConditionalOnBean(MockLoginConfig.class)
+@Hidden
+class MockLoginController {
+
+  @GetMapping(value = "/login", produces = "text/html")
+  @ResponseBody
+  public String login(CsrfToken csrf) {
+    return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>JOD Mock Login Page</title>
+          <style>
+            body {
+              font-size: 16px;
+              font-family: Arial, sans-serif;
+              background-color: #f4f4f4;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              margin: 20px;
+            }
+
+            .login-container {
+              background-color: #fff;
+              padding: 20px;
+              border-radius: 8px;
+              box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+              width: 300px;
+            }
+
+            .login-container h2 {
+              font-size: 24px;
+              margin: 10px auto 30px;
+              text-align: center;
+              box-sizing: border-box;
+            }
+
+            .login-container label {
+              display: block;
+              margin-bottom: 5px;
+              font-weight: bold;
+            }
+
+            .login-container input[type="text"],
+            .login-container input[type="password"] {
+              padding: 10px;
+              width: 100%;
+              margin-bottom: 15px;
+              border: 1px solid #ccc;
+              border-radius: 4px;
+              font-size: 16px;
+              box-sizing: border-box;
+            }
+
+            .login-container button {
+              width: 100%;
+              padding: 10px;
+              background-color: rgb(0, 109, 179);
+              border: none;
+              border-radius: 4px;
+              color: #fff;
+              font-size: 16px;
+              cursor: pointer;
+            }
+
+            .login-container button:hover {
+              background-color: rgb(0, 87, 143);
+            }
+          </style>
+        </head>
+        <body>
+        <div class="login-container">
+          <h2>JOD Yksilö Mock Login</h2>
+          <form method="post" action="/login">
+            <label for="username">Username</label>
+            <input type="text" id="username" name="username" required>
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required>
+            <button type="submit">Sign In</button>
+            <input type="hidden" name="_csrf" value="{csrf}">
+          </form>
+        </div>
+        </body>
+        </html>
+        """
+        .replace("{csrf}", csrf.getToken());
+  }
+}

--- a/src/main/java/fi/okm/jod/yksilo/config/suomifi/LoginController.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/suomifi/LoginController.java
@@ -9,6 +9,7 @@
 
 package fi.okm.jod.yksilo.config.suomifi;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +21,7 @@ import org.springframework.web.util.UriUtils;
 
 @Controller
 @ConditionalOnBean(Saml2LoginConfig.class)
+@Hidden
 class LoginController {
 
   public static final String REDIRECT_URI = "/saml2/authenticate/jodsuomifi";

--- a/src/test/java/fi/okm/jod/yksilo/controller/YksiloControllerTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/controller/YksiloControllerTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import fi.okm.jod.yksilo.domain.MockJodUserImpl;
+import fi.okm.jod.yksilo.config.mocklogin.MockJodUserImpl;
 import fi.okm.jod.yksilo.dto.YksiloDto;
 import fi.okm.jod.yksilo.errorhandler.ErrorInfoFactory;
 import fi.okm.jod.yksilo.service.YksiloService;


### PR DESCRIPTION
## Description
Fix mock login by replacing the default login page with a custom one (default login page can not be configured to accept query parameters).

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-212
