### PR TITLE
OPHJOD-646: Change ehdotus and tyomahdollisuus api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-data-redis'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
+  implementation 'org.springframework.boot:spring-boot-starter-cache'
 
   implementation 'org.springframework.session:spring-session-data-redis'
 
@@ -70,6 +71,9 @@ dependencies {
 
   // Logging in JSON format
   implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+
+  // Caffeine cache implementation
+  implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
   // OpenAPI API description and Swagger UI
   implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.6.0'

--- a/src/main/java/fi/okm/jod/yksilo/Application.java
+++ b/src/main/java/fi/okm/jod/yksilo/Application.java
@@ -13,10 +13,12 @@ import fi.okm.jod.yksilo.util.Base64ProtocolResolver;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 
 /** Application entrypoint. */
 @SpringBootApplication
 @ConfigurationPropertiesScan("fi.okm.jod.yksilo.config")
+@EnableCaching
 public class Application {
 
   public static void main(String[] args) {

--- a/src/main/java/fi/okm/jod/yksilo/entity/Tyomahdollisuus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Tyomahdollisuus.java
@@ -37,6 +37,10 @@ import org.hibernate.annotations.Immutable;
 public class Tyomahdollisuus {
   @Id private UUID id;
 
+  // TODO: change to UUID when ehdotus engine provides id in UUID format.
+  @Column(name = "json_id")
+  private String mahdollisuusId;
+
   @ElementCollection
   @MapKeyEnumerated(EnumType.STRING)
   @BatchSize(size = 1000)

--- a/src/main/java/fi/okm/jod/yksilo/entity/projection/TyomahdollisuusMetadata.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/projection/TyomahdollisuusMetadata.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.entity.projection;
+
+import java.util.UUID;
+
+// TODO: Change externalId to UUID when clustering id is changed
+public record TyomahdollisuusMetadata(UUID id, String externalId, String otsikko) {}

--- a/src/main/java/fi/okm/jod/yksilo/repository/TyomahdollisuusRepository.java
+++ b/src/main/java/fi/okm/jod/yksilo/repository/TyomahdollisuusRepository.java
@@ -11,6 +11,7 @@ package fi.okm.jod.yksilo.repository;
 
 import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.entity.Tyomahdollisuus;
+import fi.okm.jod.yksilo.entity.projection.TyomahdollisuusMetadata;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,8 @@ public interface TyomahdollisuusRepository extends JpaRepository<Tyomahdollisuus
   @Query(
       "SELECT t FROM Tyomahdollisuus t JOIN t.kaannos k WHERE k.otsikko IN :name AND KEY(k) = :kieli")
   List<Tyomahdollisuus> findByOtsikkoIn(Iterable<String> name, Kieli kieli);
+
+  @Query(
+      "SELECT new fi.okm.jod.yksilo.entity.projection.TyomahdollisuusMetadata(t.id, t.mahdollisuusId, k.otsikko) FROM Tyomahdollisuus t JOIN t.kaannos k where KEY(k) = :kieli")
+  List<TyomahdollisuusMetadata> fetchAllTyomahdollisuusMetadata(Kieli kieli);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,10 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  cache:
+    type: caffeine
+    caffeine:
+      spec: initialCapacity=100,maximumSize=500,expireAfterWrite=600s
 
 server:
   error:

--- a/src/main/resources/data-import.sql
+++ b/src/main/resources/data-import.sql
@@ -11,3 +11,4 @@ INSERT INTO osaaminen (id, uri) SELECT nextval('osaaminen_seq'), "conceptUri"  A
 INSERT INTO osaaminen_kaannos (osaaminen_id, kaannos_key,  kuvaus, nimi) SELECT o.id AS osaaminen_id, 'FI' AS kaannos_key, description AS kuvaus, "preferredLabel"  AS nimi FROM esco_data.skills_fi e JOIN osaaminen o ON o.uri = e."conceptUri";
 INSERT INTO osaaminen_kaannos (osaaminen_id, kaannos_key,  kuvaus, nimi) SELECT o.id AS osaaminen_id, 'SV' AS kaannos_key, description AS kuvaus, "preferredLabel"  AS nimi FROM esco_data.skills_sv e JOIN osaaminen o ON o.uri = e."conceptUri";
 INSERT INTO osaaminen_kaannos (osaaminen_id, kaannos_key,  kuvaus, nimi) SELECT o.id AS osaaminen_id, 'EN' AS kaannos_key, description AS kuvaus, "preferredLabel"  AS nimi FROM esco_data.skills_en e JOIN osaaminen o ON o.uri = e."conceptUri";
+

--- a/src/test/java/fi/okm/jod/yksilo/controller/TyomahdollisuusControllerTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/controller/TyomahdollisuusControllerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import fi.okm.jod.yksilo.config.mapping.MappingConfig;
+import fi.okm.jod.yksilo.domain.Kieli;
+import fi.okm.jod.yksilo.domain.LocalizedString;
+import fi.okm.jod.yksilo.dto.TyomahdollisuusDto;
+import fi.okm.jod.yksilo.errorhandler.ErrorInfoFactory;
+import fi.okm.jod.yksilo.service.TyomahdollisuusService;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@WebMvcTest(value = TyomahdollisuusController.class)
+@Import({ErrorInfoFactory.class, MappingConfig.class})
+class TyomahdollisuusControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private TyomahdollisuusService service;
+
+  @Test
+  @WithMockUser
+  void shouldFindDataByIds() throws Exception {
+
+    var mockIds = Set.of(UUID.randomUUID(), UUID.randomUUID());
+    var otsikko =
+        new LocalizedString(
+            Map.of(
+                Kieli.FI, "otsikko",
+                Kieli.EN, "title",
+                Kieli.SV, "titel"));
+    var tiivistelma =
+        new LocalizedString(
+            Map.of(
+                Kieli.FI, "Tiivistelmä",
+                Kieli.EN, "Summary",
+                Kieli.SV, "Sammanfattning"));
+    var kuvaus =
+        new LocalizedString(
+            Map.of(
+                Kieli.FI, "Kuvaus",
+                Kieli.EN, "Description",
+                Kieli.SV, "Beskrivning"));
+    var mockTyomahdolliuudet =
+        List.of(
+            new TyomahdollisuusDto(
+                mockIds.stream().findFirst().orElse(UUID.randomUUID()),
+                otsikko,
+                tiivistelma,
+                kuvaus));
+    when(service.findByIds(mockIds)).thenReturn(mockTyomahdolliuudet);
+
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    mockIds.forEach(uuid -> params.add("id", uuid.toString()));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/api/tyomahdollisuudet")
+                .with(csrf())
+                .params(params)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.maara", is(1)))
+        .andExpect(jsonPath("$.sivuja", is(1)))
+        .andExpect(jsonPath("$.sisalto", hasSize(1)))
+        .andExpect(
+            jsonPath("$.sisalto[0].id", oneOf(mockIds.stream().map(UUID::toString).toArray())))
+        .andExpect(jsonPath("$.sisalto[0].otsikko.fi", is("otsikko")))
+        .andExpect(jsonPath("$.sisalto[0].tiivistelma.fi", is("Tiivistelmä")))
+        .andExpect(jsonPath("$.sisalto[0].kuvaus.fi", is("Kuvaus")))
+        .andExpect(jsonPath("$.sisalto[0].otsikko.en", is("title")))
+        .andExpect(jsonPath("$.sisalto[0].tiivistelma.en", is("Summary")))
+        .andExpect(jsonPath("$.sisalto[0].kuvaus.en", is("Description")));
+  }
+}


### PR DESCRIPTION
Changed /api/ehdotus/tyomahdollisuudet to return list of all työmahdollisuus ehdotukset meta data with reference to työmahdollisuus. 

Added /api/tyomahdollisuudet/etsi-id endpoint with query parameter ids which can be used to request list of työmahdolliuudet.

https://jira.eduuni.fi/browse/OPHJOD-646
