### PR TITLE
OPHJOD-717: Fix session.timeout was ignored

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/config/SessionConfig.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/SessionConfig.java
@@ -26,13 +26,11 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.lang.NonNull;
 import org.springframework.security.jackson2.SecurityJackson2Modules;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.util.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 
 @Configuration(proxyBeanMethods = false)
-@EnableRedisHttpSession
 public class SessionConfig implements BeanClassLoaderAware {
 
   @Value("${spring.data.redis.cache-name:}")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ spring:
     enabled: false
   session:
     timeout: 30m
+    redis:
+      repository-type: default
   sql:
     init:
       mode: always # FIXME: Just for early development without migrations


### PR DESCRIPTION
## Description
Use redis http session auto-configuration to pick up common properties.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-717
