### PR TITLE
OPHJOD-698: Change tyomahdollisuus cluster id from string to uuid

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/TyomahdollisuudetController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/TyomahdollisuudetController.java
@@ -69,7 +69,6 @@ class TyomahdollisuudetController {
     var tyomahdollisuusMetaData = tyomahdollisuusService.fetchAllTyomahdollisuusMetadata();
 
     log.info("Creating a suggestion for tyomahdollisuudet");
-    // temporarily using names instead of IDs
 
     var osaamiset =
         ehdotus.osaamiset() == null
@@ -101,16 +100,16 @@ class TyomahdollisuudetController {
 
     var result =
         inferenceService.infer(endpoint, request, Response.class).stream()
-            .collect(Collectors.toMap(Suggestion::name, Suggestion::score, Double::max));
+            .collect(Collectors.toMap(Suggestion::id, Suggestion::score, Double::max));
 
-    // TODO: Change to use ID list when ML solution starts returning IDs
     return tyomahdollisuusMetaData.keySet().stream()
         .map(
             key ->
                 new EhdotusDto(
                     key,
                     new EhdotusMetadata(
-                        OptionalDouble.of(result.get(tyomahdollisuusMetaData.get(key).otsikko())),
+                        OptionalDouble.of(
+                            result.get(tyomahdollisuusMetaData.get(key).externalId())),
                         Optional.empty(),
                         OptionalInt.empty())))
         .sorted(Comparator.comparing(e -> e.ehdotusMetadata.pisteet.orElse(0d)))
@@ -186,6 +185,6 @@ class TyomahdollisuudetController {
 
   @SuppressWarnings("serial")
   static class Response extends ArrayList<Suggestion> {
-    record Suggestion(String name, double score) {}
+    record Suggestion(UUID id, String name, double score) {}
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/entity/Tyomahdollisuus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Tyomahdollisuus.java
@@ -37,9 +37,8 @@ import org.hibernate.annotations.Immutable;
 public class Tyomahdollisuus {
   @Id private UUID id;
 
-  // TODO: change to UUID when ehdotus engine provides id in UUID format.
   @Column(name = "json_id")
-  private String mahdollisuusId;
+  private UUID mahdollisuusId;
 
   @ElementCollection
   @MapKeyEnumerated(EnumType.STRING)

--- a/src/main/java/fi/okm/jod/yksilo/entity/projection/TyomahdollisuusMetadata.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/projection/TyomahdollisuusMetadata.java
@@ -11,5 +11,4 @@ package fi.okm.jod.yksilo.entity.projection;
 
 import java.util.UUID;
 
-// TODO: Change externalId to UUID when clustering id is changed
-public record TyomahdollisuusMetadata(UUID id, String externalId, String otsikko) {}
+public record TyomahdollisuusMetadata(UUID id, UUID externalId) {}

--- a/src/main/java/fi/okm/jod/yksilo/repository/TyomahdollisuusRepository.java
+++ b/src/main/java/fi/okm/jod/yksilo/repository/TyomahdollisuusRepository.java
@@ -24,6 +24,6 @@ public interface TyomahdollisuusRepository extends JpaRepository<Tyomahdollisuus
   List<Tyomahdollisuus> findByOtsikkoIn(Iterable<String> name, Kieli kieli);
 
   @Query(
-      "SELECT new fi.okm.jod.yksilo.entity.projection.TyomahdollisuusMetadata(t.id, t.mahdollisuusId, k.otsikko) FROM Tyomahdollisuus t JOIN t.kaannos k where KEY(k) = :kieli")
-  List<TyomahdollisuusMetadata> fetchAllTyomahdollisuusMetadata(Kieli kieli);
+      "SELECT new fi.okm.jod.yksilo.entity.projection.TyomahdollisuusMetadata(t.id, t.mahdollisuusId) FROM Tyomahdollisuus t")
+  List<TyomahdollisuusMetadata> fetchAllTyomahdollisuusMetadata();
 }

--- a/src/main/java/fi/okm/jod/yksilo/service/TyomahdollisuusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/TyomahdollisuusService.java
@@ -9,7 +9,6 @@
 
 package fi.okm.jod.yksilo.service;
 
-import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.dto.ArvoDto;
 import fi.okm.jod.yksilo.dto.JakaumaDto;
 import fi.okm.jod.yksilo.dto.TyomahdollisuusDto;
@@ -72,8 +71,7 @@ public class TyomahdollisuusService {
 
   @Cacheable("tyomahdollisuusMetadata")
   public Map<UUID, TyomahdollisuusMetadata> fetchAllTyomahdollisuusMetadata() {
-    // Remove Kieli when UUID mapping possible
-    return tyomahdollisuusRepository.fetchAllTyomahdollisuusMetadata(Kieli.FI).stream()
+    return tyomahdollisuusRepository.fetchAllTyomahdollisuusMetadata().stream()
         .collect(
             Collectors.toMap(
                 TyomahdollisuusMetadata::id,


### PR DESCRIPTION
## Description

This PR changes the id type of the työmahdollisuus from varchar to uuid. And starts using the mapping by the ID instead of the title of työmahdollisuus 

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-698

This PR can't be merged before the following changes have been deployed:
https://jira.eduuni.fi/browse/OPHJOD-682 
https://jira.eduuni.fi/browse/OPHJOD-714

And needs to be merged with realated infra changes PR: https://github.com/Opetushallitus/jod-yksilo-infra/pull/41

## Test locally
Update tyomahdollisuudet data from S3 and manually alter tyomahdollisuus.json_id from varchar to uuid.
