### PR TITLE
OPHJOD-862: Fix EhdotusMetadata tyyppi to not null in dto schema

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/MahdollisuudetController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/MahdollisuudetController.java
@@ -22,6 +22,7 @@ import io.micrometer.core.annotation.Timed;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.net.URI;
 import java.util.ArrayList;
@@ -89,7 +90,7 @@ class MahdollisuudetController {
     ids.addAll(tyomahdollisuusIds);
     ids.addAll(koulutusmahdollisuusService.fetchAllIds());
 
-    log.info("Creating a suggestion for tyomahdollisuudet");
+    log.info("Creating the suggestions");
 
     var osaamiset =
         ehdotus.osaamiset() == null
@@ -192,7 +193,7 @@ class MahdollisuudetController {
    *     opportunity associated with the proposal has been employed.
    */
   public record EhdotusMetadata(
-      MahdollisuusTyyppi tyyppi,
+      @NotNull MahdollisuusTyyppi tyyppi,
       @Nullable Double pisteet,
       @Nullable Trendi trendi,
 


### PR DESCRIPTION
## Description

Metadata type changed to not null. Since each opportunity must have a fixed type it is logical, that type can't be null.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-862
