### PR TITLE
OPHJOD-1043: Allow non-printable characters for competence matcher

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/OsaamisetEhdotusController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/OsaamisetEhdotusController.java
@@ -12,7 +12,6 @@ package fi.okm.jod.yksilo.controller.ehdotus;
 import fi.okm.jod.yksilo.domain.LocalizedString;
 import fi.okm.jod.yksilo.service.ehdotus.OsaamisetEhdotusService;
 import fi.okm.jod.yksilo.service.ehdotus.OsaamisetEhdotusService.Ehdotus;
-import fi.okm.jod.yksilo.validation.PrintableString;
 import io.micrometer.core.annotation.Timed;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
@@ -39,7 +38,7 @@ class OsaamisetEhdotusController {
   @PostMapping
   @Timed
   public ResponseEntity<List<Ehdotus>> createEhdotus(
-      @RequestBody @NotNull @Size(min = 2, max = 10_000) @PrintableString LocalizedString kuvaus) {
+      @RequestBody @NotNull @Size(min = 2, max = 10_000) LocalizedString kuvaus) {
     if (kuvaus.asMap().keySet().size() > 1) {
       throw new IllegalArgumentException("Ambiguous request, only one language version allowed");
     }


### PR DESCRIPTION
## Description

Validate competence matching API only for max 10000 chars. And alllow non-printable chars as newline, tabs, etc.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1043
