### PR TITLE
OPHJOD-1133: Add lexicalIndex to opportunity metadata

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/config/mapping/StringToKieliConverter.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mapping/StringToKieliConverter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.config.mapping;
+
+import fi.okm.jod.yksilo.domain.Kieli;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToKieliConverter implements Converter<String, Kieli> {
+  @Override
+  public Kieli convert(String source) {
+    try {
+      return Kieli.valueOf(source.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      // return FI as default value
+      return Kieli.FI;
+    }
+  }
+}

--- a/src/main/java/fi/okm/jod/yksilo/config/mapping/StringToSortDirectionConverter.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mapping/StringToSortDirectionConverter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.config.mapping;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToSortDirectionConverter implements Converter<String, Sort.Direction> {
+  @Override
+  public Sort.Direction convert(String source) {
+    try {
+      return Sort.Direction.valueOf(source.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      // return asc as default value
+      return Sort.Direction.ASC;
+    }
+  }
+}

--- a/src/main/java/fi/okm/jod/yksilo/service/KoulutusmahdollisuusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/KoulutusmahdollisuusService.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -95,10 +94,5 @@ public class KoulutusmahdollisuusService {
         koulutusmahdollisuudet
             .findById(id)
             .orElseThrow(() -> new NotFoundException("Unknown Koulutusmahdollisuus")));
-  }
-
-  @Cacheable("koulutusmahdollisuusMetadata")
-  public Set<UUID> fetchAllIds() {
-    return koulutusmahdollisuudet.fetchAllIds();
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/service/TyomahdollisuusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/TyomahdollisuusService.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -35,11 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TyomahdollisuusService {
   private final TyomahdollisuusRepository tyomahdollisuusRepository;
-
-  @Cacheable("tyomahdollisuusMetadata")
-  public Set<UUID> fetchAllIds() {
-    return tyomahdollisuusRepository.fetchAllIds();
-  }
 
   public Page<TyomahdollisuusDto> findAll(Pageable pageable) {
     return tyomahdollisuusRepository

--- a/src/main/java/fi/okm/jod/yksilo/service/ehdotus/MahdollisuudetService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/ehdotus/MahdollisuudetService.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.service.ehdotus;
+
+import fi.okm.jod.yksilo.domain.Kieli;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MahdollisuudetService {
+
+  private static final String SQL_UNION_OF_TYO_AND_KOULUTUSMAHDOLLISUUS_IDS =
+      """
+    SELECT tyomahdollisuus_id AS id, otsikko, 'TYOMAHDOLLISUUS' AS tyyppi
+    FROM tyomahdollisuus_kaannos tk
+    WHERE kaannos_key = :lang
+    UNION
+    SELECT koulutusmahdollisuus_id AS id, otsikko, 'KOULUTUSMAHDOLLISUUS' AS tyyppi
+    FROM koulutusmahdollisuus_kaannos kk
+    WHERE kaannos_key = :lang
+    ORDER BY otsikko
+    """;
+
+  private static final String SQL_UNION_OF_TYO_AND_KOULUTUSMAHDOLLISUUS_IDS_ASC =
+      SQL_UNION_OF_TYO_AND_KOULUTUSMAHDOLLISUUS_IDS + " ASC";
+
+  private static final String SQL_UNION_OF_TYO_AND_KOULUTUSMAHDOLLISUUS_IDS_DESC =
+      SQL_UNION_OF_TYO_AND_KOULUTUSMAHDOLLISUUS_IDS + " DESC";
+
+  private final EntityManager entityManager;
+
+  @PostConstruct
+  @CacheEvict(value = "mahdollisuusIdsAndTypes", allEntries = true)
+  public void clearCacheAtStartup() {
+    // This method will clear all entries in the "tyomahdollisuusMetadata" cache at startup
+  }
+
+  @Cacheable("mahdollisuusIdsAndTypes")
+  public LinkedHashMap<UUID, MahdollisuusTyyppi> fetchTyoAndKoulutusMahdollisuusIdsWithTypes(
+      Sort.Direction sort, Kieli lang) {
+    // fetch id's and title translation directly from translations
+    Query nativeQuery =
+        entityManager
+            .createNativeQuery(
+                sort == Sort.Direction.ASC
+                    ? SQL_UNION_OF_TYO_AND_KOULUTUSMAHDOLLISUUS_IDS_ASC
+                    : SQL_UNION_OF_TYO_AND_KOULUTUSMAHDOLLISUUS_IDS_DESC,
+                TypedResult.class)
+            .setParameter("lang", lang.name().toUpperCase());
+    @SuppressWarnings("unchecked")
+    List<TypedResult> results = nativeQuery.getResultList();
+    return results.stream()
+        .collect(
+            Collectors.toMap(
+                result -> result.id, // Key mapper
+                result -> MahdollisuusTyyppi.valueOf(result.tyyppi), // Value mapper
+                (existing, replacement) -> existing, // Merge function in case of duplicates
+                LinkedHashMap::new // Supplier for the LinkedHashMap
+                ));
+  }
+
+  public enum MahdollisuusTyyppi {
+    TYOMAHDOLLISUUS,
+    KOULUTUSMAHDOLLISUUS;
+  };
+
+  record TypedResult(UUID id, String otsikko, String tyyppi) {}
+}


### PR DESCRIPTION
## Description

Added sort property and Content-Language header support to /api/ehdotus/mahdollisuudet.

This change allows frontend to sort combined opportunities alphabetically by user selected language.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1133
