### PR TITLE
OPHJOD-1329: Pass client's user's language to Koski OAuth2

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/controller/koski/KoskiOAuth2Controller.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/koski/KoskiOAuth2Controller.java
@@ -49,16 +49,19 @@ public class KoskiOAuth2Controller {
     request
         .getSession()
         .setAttribute(SessionLoginAttribute.CALLBACK_FRONTEND.getKey(), callbackPath);
-
     var authorizationUrl = getAuthorizationUrl(request);
     log.debug("Redirect user to {}, callback: {}", authorizationUrl, callbackPath);
     response.sendRedirect(authorizationUrl);
   }
 
   private String getAuthorizationUrl(HttpServletRequest request) {
-    return request.getContextPath()
-        + "/oauth2/authorization/"
-        + koskiOAuth2Service.getRegistrationId();
+    var language = request.getParameter("lang") != null ? request.getParameter("lang") : "fi";
+    return UriComponentsBuilder.fromUriString(
+            request.getContextPath()
+                + "/oauth2/authorization/"
+                + koskiOAuth2Service.getRegistrationId())
+        .queryParam("locale", language)
+        .toUriString();
   }
 
   /**

--- a/src/test/java/fi/okm/jod/yksilo/controller/koski/KoskiOAuth2ControllerTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/controller/koski/KoskiOAuth2ControllerTest.java
@@ -75,7 +75,7 @@ class KoskiOAuth2ControllerTest {
   }
 
   @Test
-  void shouldRedirectToOAuth2Url_whenCallbackExists() throws Exception {
+  void shouldRedirectToOAuth2Url_whenNoLangParameter() throws Exception {
     when(koskiOAuth2Service.getRegistrationId()).thenReturn(REGISTRATION_ID);
 
     var fullCallbackUrlWithParameters =
@@ -87,7 +87,30 @@ class KoskiOAuth2ControllerTest {
             .perform(
                 get("/oauth2/authorize/koski").param("callback", fullCallbackUrlWithParameters))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl(AUTHORIZATION_URL))
+            .andExpect(redirectedUrl(AUTHORIZATION_URL + "?locale=fi"))
+            .andReturn();
+
+    var session = result.getRequest().getSession();
+    assertThat(session.getAttribute(SessionLoginAttribute.CALLBACK_FRONTEND.getKey()))
+        .isEqualTo(CALLBACK_PATH);
+  }
+
+  @Test
+  void shouldRedirectToOAuth2Url() throws Exception {
+    when(koskiOAuth2Service.getRegistrationId()).thenReturn(REGISTRATION_ID);
+
+    var fullCallbackUrlWithParameters =
+        "http://localhost:8080/koski/fi/omat-sivuni/osaamiseni/koulutukseni?callback="
+            + CALLBACK_PATH
+            + "&extra=blablabla";
+    var result =
+        mockMvc
+            .perform(
+                get("/oauth2/authorize/koski")
+                    .param("callback", fullCallbackUrlWithParameters)
+                    .param("lang", "en"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(AUTHORIZATION_URL + "?locale=en"))
             .andReturn();
 
     var session = result.getRequest().getSession();


### PR DESCRIPTION
This update ensures that the user's selected language (locale) is included in OAuth2 authorization requests, so that Koski can show correct language for the user.

<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1329
