### PR TITLE
OPHJOD-1357: Improve education description get from Koski import  

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/config/koski/KoskiRestClientConfig.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/koski/KoskiRestClientConfig.java
@@ -57,8 +57,8 @@ public class KoskiRestClientConfig {
             .build(
                 ClientHttpRequestFactorySettings.defaults()
                     .withSslBundle(sslBundles.getBundle(SSL_BUNDLE))
-                    .withConnectTimeout(Duration.ofSeconds(5))
-                    .withReadTimeout(Duration.ofSeconds(10)));
+                    .withConnectTimeout(Duration.ofSeconds(10))
+                    .withReadTimeout(Duration.ofSeconds(30)));
 
     return builder
         .requestFactory(requestFactory)

--- a/src/main/java/fi/okm/jod/yksilo/controller/koski/IntegraatioKoskiController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/koski/IntegraatioKoskiController.java
@@ -72,7 +72,7 @@ public class IntegraatioKoskiController {
       }
       koskiOAuth2Service.checkPersonIdMatches(jodUser, dataInJson);
 
-      var educationHistories = koskiService.getKoulutusData(dataInJson, null);
+      var educationHistories = koskiService.getKoulutusData(dataInJson);
       return ResponseEntity.ok(educationHistories);
 
     } catch (WrongPersonException e) {

--- a/src/main/java/fi/okm/jod/yksilo/controller/koski/KoskiOAuth2Controller.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/koski/KoskiOAuth2Controller.java
@@ -99,6 +99,8 @@ public class KoskiOAuth2Controller {
         handleUserDidNotGivePermission(response, jodUser, callbackUrl);
         return;
       }
+      // This happens when network is not okay. For example server IP is not in allow the Koski
+      // list.
       log.error(
           "Koski OAuth2 authorize failed. Error: {}, description: {}", error, errorDescription);
       response.sendRedirect(createRedirectUrl(callbackUrl.toString(), "error"));

--- a/src/test/java/fi/okm/jod/yksilo/controller/koski/IntegraatioKoskiControllerTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/controller/koski/IntegraatioKoskiControllerTest.java
@@ -78,7 +78,7 @@ class IntegraatioKoskiControllerTest {
             TestUtil.getContentFromFile(EDUCATIONS_HISTORY_KOSKI_RESPONSE, KoskiService.class));
     when(koskiOAuth2Service.fetchDataFromResourceServer(mockAuthorizedClient))
         .thenReturn(mockDataInJson);
-    when(koskiService.getKoulutusData(mockDataInJson, null))
+    when(koskiService.getKoulutusData(mockDataInJson))
         .thenReturn(
             List.of(
                 new KoulutusDto(
@@ -100,7 +100,7 @@ class IntegraatioKoskiControllerTest {
     performGetEducationsDataFromKoski(status().isOk(), expectedResponseJson);
 
     verify(koskiOAuth2Service).fetchDataFromResourceServer(mockAuthorizedClient);
-    verify(koskiService).getKoulutusData(mockDataInJson, null);
+    verify(koskiService).getKoulutusData(mockDataInJson);
   }
 
   @Test

--- a/src/test/java/fi/okm/jod/yksilo/service/koski/KoskiServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/koski/KoskiServiceTest.java
@@ -10,13 +10,16 @@
 package fi.okm.jod.yksilo.service.koski;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.okm.jod.yksilo.domain.Kieli;
+import fi.okm.jod.yksilo.domain.LocalizedString;
 import fi.okm.jod.yksilo.testutil.TestUtil;
 import java.time.LocalDate;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class KoskiServiceTest {
@@ -32,7 +35,7 @@ class KoskiServiceTest {
   @Test
   void getKoulutusData() throws JsonProcessingException {
     var content = TestUtil.getContentFromFile("koski-response.json", this.getClass());
-    var koskiData = koskiService.getKoulutusData(objectMapper.readTree(content), null);
+    var koskiData = koskiService.getKoulutusData(objectMapper.readTree(content));
 
     assertEquals(1, koskiData.size());
     var koulutusDto = koskiData.getFirst();
@@ -51,5 +54,19 @@ class KoskiServiceTest {
     assertEquals(LocalDate.of(2006, 1, 1), koulutusDto.alkuPvm());
     assertNull(koulutusDto.loppuPvm());
     assertNull(koulutusDto.osaamiset());
+  }
+
+  @Test
+  void testGetLocalizedKuvaus() {
+    var description =
+        new LocalizedString(Map.of(Kieli.FI, "Avoimen opinnot", Kieli.SV, "Öppna studier"));
+    var name = new LocalizedString(Map.of(Kieli.FI, "Lisätietoja", Kieli.EN, "Additional info"));
+
+    var result = KoskiService.getLocalizedKuvaus(description, name);
+
+    assertNotNull(result);
+    assertEquals(2, result.asMap().size());
+    assertEquals("Avoimen opinnot: Lisätietoja", result.get(Kieli.FI));
+    assertEquals("Öppna studier", result.get(Kieli.SV));
   }
 }


### PR DESCRIPTION
## Description

This pull request improves education's import description provided to client and robustness in the system:
- Refactored `KoskiService` to manage and merge localized descriptions effectively using a new `getLocalizedKuvaus` helper method that have default fallback language to Finnish if text is missing. E.g. previously "Avoimen opinnot", now have more detail info: "Avoimen opinnot: Aducate/A1999/Avoin yo, kasv./Kasvatustiede/Kasvat. appr"
- Increased HTTP client timeout values in `KoskiRestClientConfig` to better handle slower API responses and reduce timeout errors.
- Removed unused code.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1357