### PR TITLE
OPHJOD-1310: Implement AI-based osaamiset tunnistus for Koski import

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/Application.java
+++ b/src/main/java/fi/okm/jod/yksilo/Application.java
@@ -13,8 +13,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 /** Application entrypoint. */
+@EnableAsync
 @SpringBootApplication
 @ConfigurationPropertiesScan("fi.okm.jod.yksilo.config")
 @EnableCaching

--- a/src/main/java/fi/okm/jod/yksilo/config/AwsTracingConfig.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/AwsTracingConfig.java
@@ -14,6 +14,8 @@ import brave.propagation.aws.AWSPropagation;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
 
 /**
  * Configures trace id propagation for micrometer tracing
@@ -28,5 +30,10 @@ public class AwsTracingConfig {
   @Bean
   public Propagation.Factory awsTracePropagation() {
     return AWSPropagation.FACTORY;
+  }
+
+  @Bean
+  public TaskDecorator taskDecorator() {
+    return new ContextPropagatingTaskDecorator();
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/controller/KeskusteluController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/KeskusteluController.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -51,7 +52,7 @@ public class KeskusteluController {
             endpoint,
             null,
             new Request(entry.getValue(), entry.getKey().toString()),
-            Response.class);
+            new ParameterizedTypeReference<>() {});
     return new ResponseWithId(
         response.sessionId(), response.data().kiinnostukset(), response.data().response());
   }
@@ -67,7 +68,10 @@ public class KeskusteluController {
     var entry = kuvaus.asMap().entrySet().iterator().next();
     var response =
         inferenceService.infer(
-            endpoint, id, new Request(entry.getValue(), entry.getKey().toString()), Response.class);
+            endpoint,
+            id,
+            new Request(entry.getValue(), entry.getKey().toString()),
+            new ParameterizedTypeReference<>() {});
     return new ResponseWithId(
         response.sessionId(), response.data().kiinnostukset(), response.data().response());
   }

--- a/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/MahdollisuudetController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/ehdotus/MahdollisuudetController.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -122,7 +123,7 @@ class MahdollisuudetController {
             new Data(
                 ehdotus.osaamisPainotus, osaamiset, ehdotus.kiinnostusPainotus, kiinnostukset));
 
-    return inferenceService.infer(endpoint, request, Response.class).stream()
+    return inferenceService.infer(endpoint, request, new ParameterizedTypeReference<>() {}).stream()
         .collect(Collectors.toMap(Suggestion::id, r -> r, (exising, newValue) -> exising));
   }
 

--- a/src/main/java/fi/okm/jod/yksilo/controller/profiili/KoulutusKokonaisuusController.java
+++ b/src/main/java/fi/okm/jod/yksilo/controller/profiili/KoulutusKokonaisuusController.java
@@ -53,10 +53,10 @@ class KoulutusKokonaisuusController {
   @PostMapping("/tuonti")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(summary = "Adds many new koulutuskokonaisuudet, and optionally associated koulutukset")
-  void addMany(
+  List<UUID> addMany(
       @Validated(Add.class) @RequestBody Set<KoulutusKokonaisuusDto> dtos,
       @AuthenticationPrincipal JodUser user) {
-    service.addMany(user, dtos);
+    return service.addManyForImport(user, dtos);
   }
 
   @PostMapping

--- a/src/main/java/fi/okm/jod/yksilo/dto/profiili/KoulutusDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/profiili/KoulutusDto.java
@@ -27,5 +27,8 @@ public record KoulutusDto(
     @Size(max = 10000) @PrintableString LocalizedString kuvaus,
     LocalDate alkuPvm,
     LocalDate loppuPvm,
-    Set<@NotNull URI> osaamiset)
+    Set<@NotNull URI> osaamiset,
+    Boolean osaamisetOdottaaTunnistusta,
+    Boolean osaamisetTunnistusEpaonnistui,
+    Set<String> osasuoritukset)
     implements ValidInterval {}

--- a/src/main/java/fi/okm/jod/yksilo/entity/Koulutus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/Koulutus.java
@@ -23,12 +23,14 @@ import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapKeyEnumerated;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.EnumMap;
@@ -62,6 +64,12 @@ public class Koulutus implements OsaamisenLahde {
   @OneToMany(mappedBy = "koulutus", fetch = FetchType.LAZY)
   @BatchSize(size = 100)
   private Set<YksilonOsaaminen> osaamiset;
+
+  @Setter
+  @Enumerated(EnumType.STRING)
+  private OsaamisenTunnistusStatus osaamisenTunnistusStatus; // null = No need for tunnistus.
+
+  @Setter @Transient private Set<String> osasuoritukset;
 
   protected Koulutus() {
     // For JPA

--- a/src/main/java/fi/okm/jod/yksilo/entity/OsaamisenTunnistusStatus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/OsaamisenTunnistusStatus.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.entity;
+
+public enum OsaamisenTunnistusStatus {
+  WAIT,
+  DONE,
+  FAIL,
+}

--- a/src/main/java/fi/okm/jod/yksilo/event/OsaamisetTunnistusEvent.java
+++ b/src/main/java/fi/okm/jod/yksilo/event/OsaamisetTunnistusEvent.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.event;
+
+import fi.okm.jod.yksilo.domain.JodUser;
+import fi.okm.jod.yksilo.entity.Koulutus;
+import java.util.List;
+
+public record OsaamisetTunnistusEvent(JodUser jodUser, List<Koulutus> koulutukset) {}

--- a/src/main/java/fi/okm/jod/yksilo/event/OsaamisetTunnistusEventHandler.java
+++ b/src/main/java/fi/okm/jod/yksilo/event/OsaamisetTunnistusEventHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.event;
+
+import fi.okm.jod.yksilo.domain.Kieli;
+import fi.okm.jod.yksilo.entity.Koulutus;
+import fi.okm.jod.yksilo.entity.OsaamisenTunnistusStatus;
+import fi.okm.jod.yksilo.service.inference.InferenceService;
+import fi.okm.jod.yksilo.service.profiili.KoulutusService;
+import java.net.URI;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+public class OsaamisetTunnistusEventHandler {
+
+  private final KoulutusService koulutusService;
+  private final String aiTunnistusOsaamisetEndpoint;
+  private final InferenceService<SageMakerRequest, SageMakerResponse> inferenceService;
+
+  public OsaamisetTunnistusEventHandler(
+      KoulutusService koulutusService,
+      @Value("${jod.ai-tunnistus.osaamiset.endpoint}") String aiTunnistusOsaamisetEndpoint,
+      InferenceService<SageMakerRequest, SageMakerResponse> inferenceService) {
+    this.koulutusService = koulutusService;
+    this.aiTunnistusOsaamisetEndpoint = aiTunnistusOsaamisetEndpoint;
+    this.inferenceService = inferenceService;
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Async
+  public CompletableFuture<Void> handleOsaamisetTunnistusEvent(OsaamisetTunnistusEvent event) {
+    log.debug("Osaamiset tunnistus event: {}", event);
+    var koulutukset = event.koulutukset();
+    for (var koulutus : koulutukset) {
+      try {
+        var osaamisetTunnistusResponses = callIdentifyOsaamisetApi(koulutus);
+        koulutusService.updateOsaamisetTunnistusStatus(
+            koulutus, OsaamisenTunnistusStatus.DONE, osaamisetTunnistusResponses.osaamiset());
+
+      } catch (Exception e) {
+        if (e instanceof IdentifyOsaamisetException) {
+          log.error(e.getMessage(), e);
+        } else {
+          log.error("Fail to processing OsaamisetTunnistusEvent.", e);
+        }
+        koulutusService.updateOsaamisetTunnistusStatus(
+            koulutus, OsaamisenTunnistusStatus.FAIL, null);
+      }
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  private SageMakerResponse callIdentifyOsaamisetApi(Koulutus koulutus) {
+    try {
+      var request =
+          new SageMakerRequest(
+              koulutus.getId(), koulutus.getNimi().get(Kieli.FI), koulutus.getOsasuoritukset());
+
+      return inferenceService.infer(
+          aiTunnistusOsaamisetEndpoint, request, new ParameterizedTypeReference<>() {});
+
+    } catch (Exception e) {
+      throw new IdentifyOsaamisetException("Error calling OsaamisetTunnistus AI API.", e);
+    }
+  }
+
+  record SageMakerRequest(UUID id, String nimi, Set<String> osasuoritukset) {}
+
+  record SageMakerResponse(UUID id, Set<URI> osaamiset) {}
+
+  private static class IdentifyOsaamisetException extends RuntimeException {
+    public IdentifyOsaamisetException(String message, Exception exception) {
+      super(message, exception);
+    }
+  }
+}

--- a/src/main/java/fi/okm/jod/yksilo/service/inference/InferenceService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/inference/InferenceService.java
@@ -10,12 +10,14 @@
 package fi.okm.jod.yksilo.service.inference;
 
 import java.util.UUID;
+import org.springframework.core.ParameterizedTypeReference;
 
 public interface InferenceService<T, R> {
 
-  R infer(String endpoint, T payload, Class<R> responseType);
+  R infer(String endpoint, T payload, ParameterizedTypeReference<R> responseType);
 
-  InferenceSession<R> infer(String endpoint, UUID sessionId, T payload, Class<R> responseType);
+  InferenceSession<R> infer(
+      String endpoint, UUID sessionId, T payload, ParameterizedTypeReference<R> responseType);
 
   record InferenceSession<R>(R data, UUID sessionId) {}
 }

--- a/src/main/java/fi/okm/jod/yksilo/service/inference/RestInferenceService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/inference/RestInferenceService.java
@@ -14,13 +14,14 @@ import java.time.Duration;
 import java.util.UUID;
 import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
 @Component
-@Profile("default")
+@Profile("!cloud")
 public class RestInferenceService<T, R> implements InferenceService<T, R> {
 
   private final RestClient restClient;
@@ -46,7 +47,7 @@ public class RestInferenceService<T, R> implements InferenceService<T, R> {
   }
 
   @Override
-  public R infer(String endpoint, T payload, Class<R> responseType) {
+  public R infer(String endpoint, T payload, ParameterizedTypeReference<R> responseType) {
     try {
       return restClient.post().uri(endpoint).body(payload).retrieve().body(responseType);
     } catch (RestClientException e) {
@@ -56,7 +57,7 @@ public class RestInferenceService<T, R> implements InferenceService<T, R> {
 
   @Override
   public InferenceSession<R> infer(
-      String endpoint, UUID sessionId, T payload, Class<R> responseType) {
+      String endpoint, UUID sessionId, T payload, ParameterizedTypeReference<R> responseType) {
     throw new UnsupportedOperationException("Session is not supported by this inference service");
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/KoulutusKokonaisuusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/KoulutusKokonaisuusService.java
@@ -12,17 +12,21 @@ package fi.okm.jod.yksilo.service.profiili;
 import fi.okm.jod.yksilo.domain.JodUser;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusKokonaisuusDto;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusKokonaisuusUpdateDto;
+import fi.okm.jod.yksilo.entity.Koulutus;
 import fi.okm.jod.yksilo.entity.KoulutusKokonaisuus;
+import fi.okm.jod.yksilo.event.OsaamisetTunnistusEvent;
 import fi.okm.jod.yksilo.repository.KoulutusKokonaisuusRepository;
 import fi.okm.jod.yksilo.repository.YksiloRepository;
 import fi.okm.jod.yksilo.service.NotFoundException;
 import fi.okm.jod.yksilo.service.ServiceException;
 import fi.okm.jod.yksilo.service.ServiceValidationException;
 import fi.okm.jod.yksilo.validation.Limits;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +38,7 @@ public class KoulutusKokonaisuusService {
   private final YksiloRepository yksilot;
   private final KoulutusKokonaisuusRepository kokonaisuudet;
   private final KoulutusService koulutusService;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   public List<KoulutusKokonaisuusDto> findAll(JodUser user) {
     return kokonaisuudet.findByYksiloId(user.getId()).stream()
@@ -41,11 +46,22 @@ public class KoulutusKokonaisuusService {
         .toList();
   }
 
-  public void addMany(JodUser user, Set<KoulutusKokonaisuusDto> dtos) {
-    dtos.forEach(dto -> add(user, dto));
+  public List<UUID> addManyForImport(JodUser user, Set<KoulutusKokonaisuusDto> dtos) {
+    var entities = new ArrayList<Koulutus>();
+    for (KoulutusKokonaisuusDto dto : dtos) {
+      var koulutusList = add(user, dto, true).getKoulutukset();
+      entities.addAll(koulutusList);
+    }
+    applicationEventPublisher.publishEvent(new OsaamisetTunnistusEvent(user, entities));
+    return entities.stream().map(Koulutus::getId).toList();
   }
 
   public UUID add(JodUser user, KoulutusKokonaisuusDto dto) {
+    return add(user, dto, null).getId();
+  }
+
+  private KoulutusKokonaisuus add(
+      JodUser user, KoulutusKokonaisuusDto dto, Boolean odottaaOsaamisetTunnistusta) {
     var yksilo = yksilot.getReferenceById(user.getId());
     if (kokonaisuudet.countByYksilo(yksilo) >= Limits.KOULUTUSKOKONAISUUS) {
       throw new ServiceValidationException("Too many KoulutusKokonaisuus");
@@ -54,13 +70,13 @@ public class KoulutusKokonaisuusService {
     var entity =
         kokonaisuudet.save(
             new KoulutusKokonaisuus(yksilot.getReferenceById(user.getId()), dto.nimi()));
-    if (dto.koulutukset() != null) {
-      for (var koulutus : dto.koulutukset()) {
-        entity.getKoulutukset().add(koulutusService.add(entity, koulutus));
-      }
+    for (var koulutus : dto.koulutukset()) {
+      entity
+          .getKoulutukset()
+          .add(koulutusService.add(entity, koulutus, odottaaOsaamisetTunnistusta));
     }
 
-    return entity.getId();
+    return entity;
   }
 
   public KoulutusKokonaisuusDto get(JodUser user, UUID id) {

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/Mapper.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/Mapper.java
@@ -29,6 +29,7 @@ import fi.okm.jod.yksilo.dto.profiili.YksilonOsaaminenDto;
 import fi.okm.jod.yksilo.entity.Koulutus;
 import fi.okm.jod.yksilo.entity.KoulutusKokonaisuus;
 import fi.okm.jod.yksilo.entity.Osaaminen;
+import fi.okm.jod.yksilo.entity.OsaamisenTunnistusStatus;
 import fi.okm.jod.yksilo.entity.Paamaara;
 import fi.okm.jod.yksilo.entity.Patevyys;
 import fi.okm.jod.yksilo.entity.PolunSuunnitelma;
@@ -37,9 +38,12 @@ import fi.okm.jod.yksilo.entity.Toimenkuva;
 import fi.okm.jod.yksilo.entity.Toiminto;
 import fi.okm.jod.yksilo.entity.Tyopaikka;
 import fi.okm.jod.yksilo.entity.YksilonOsaaminen;
+import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.lang.NonNull;
@@ -82,9 +86,28 @@ public final class Mapper {
             entity.getKuvaus(),
             entity.getAlkuPvm(),
             entity.getLoppuPvm(),
-            entity.getOsaamiset().stream()
-                .map(o -> o.getOsaaminen().getUri())
-                .collect(Collectors.toUnmodifiableSet()));
+            extractOsaamisetUris(entity),
+            isOsaamisetOdottaaTunnistusta(entity.getOsaamisenTunnistusStatus()),
+            isOsaamisetTunnistusEpaonnistui(entity.getOsaamisenTunnistusStatus()),
+            entity.getOsasuoritukset());
+  }
+
+  private static Set<URI> extractOsaamisetUris(Koulutus entity) {
+    if (entity.getOsaamiset() == null) {
+      return Collections.emptySet();
+    }
+
+    return entity.getOsaamiset().stream()
+        .map(o -> o.getOsaaminen().getUri())
+        .collect(Collectors.toSet());
+  }
+
+  private static Boolean isOsaamisetOdottaaTunnistusta(OsaamisenTunnistusStatus status) {
+    return status == null ? null : status == OsaamisenTunnistusStatus.WAIT;
+  }
+
+  private static Boolean isOsaamisetTunnistusEpaonnistui(OsaamisenTunnistusStatus status) {
+    return status == null ? null : status == OsaamisenTunnistusStatus.FAIL;
   }
 
   public static ToimintoDto mapToiminto(Toiminto entity) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,9 +95,7 @@ jod:
     mahdollisuus:
       endpoint: ""
   keskustelu:
-    endpoint:
-  integraatio:
-    koski:
-      hosts:
-        - "testiopintopolku.fi"
-        - "opintopolku.fi"
+    endpoint: ""
+  ai-tunnistus:
+    osaamiset:
+      endpoint: ""

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,6 +6,11 @@ INSERT INTO ammatti_versio(versio)
 VALUES (0)
 ON CONFLICT DO NOTHING;
 
+--- temporary recovery for failed competence detection tasks
+UPDATE koulutus
+SET osaamisen_tunnistus_status = 'FAIL'
+WHERE osaamisen_tunnistus_status = 'WAIT';
+
 DO
 $$
   BEGIN

--- a/src/test/java/fi/okm/jod/yksilo/ApplicationTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/ApplicationTest.java
@@ -12,38 +12,31 @@ package fi.okm.jod.yksilo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import fi.okm.jod.yksilo.testutil.TestUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
-@SpringBootTest
+@AutoConfigureMockMvc
 @EnableAutoConfiguration(
     exclude = ObservationAutoConfiguration.class /* excluded due to intermittent test failures */)
-@DirtiesContext
-@Testcontainers
-@AutoConfigureMockMvc
-class ApplicationTest {
+class ApplicationTest implements IntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired protected MockMvc mockMvc;
 
   @Container @ServiceConnection
-  static GenericContainer<?> redisContainer =
-      new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+  private static final GenericContainer<?> REDIS_CONTAINER = TestUtil.createRedisContainer();
 
   @Container @ServiceConnection
-  static PostgreSQLContainer<?> postgreSQLContainer =
-      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"));
+  private static final PostgreSQLContainer<?> POSTGRES_SQL_CONTAINER =
+      TestUtil.createPostgresSQLContainer();
 
   @Test
   void contextLoads() throws Exception {

--- a/src/test/java/fi/okm/jod/yksilo/IntegrationTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/IntegrationTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public interface IntegrationTest {}

--- a/src/test/java/fi/okm/jod/yksilo/controller/koski/IntegraatioKoskiControllerTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/controller/koski/IntegraatioKoskiControllerTest.java
@@ -87,8 +87,10 @@ class IntegraatioKoskiControllerTest {
                     ls(Kieli.FI, "Kuvaus", Kieli.EN, "Description", Kieli.SV, "Beskrivning"),
                     LocalDate.of(2006, 1, 1), // alkuPvm
                     null, // loppuPvm is null
-                    null // osaamiset is null
-                    )));
+                    null, // osaamiset is null
+                    true, // osaamisetOdottaaTunnistusta
+                    null,
+                    null)));
     doAnswer(invocationOnMock -> null)
         .when(koskiOAuth2Service)
         .checkPersonIdMatches(any(JodUser.class), any(JsonNode.class));

--- a/src/test/java/fi/okm/jod/yksilo/controller/profiili/KoulutusKokonaisuusControllerTestIT.java
+++ b/src/test/java/fi/okm/jod/yksilo/controller/profiili/KoulutusKokonaisuusControllerTestIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.controller.profiili;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import fi.okm.jod.yksilo.IntegrationTest;
+import fi.okm.jod.yksilo.domain.Kieli;
+import fi.okm.jod.yksilo.entity.Koulutus;
+import fi.okm.jod.yksilo.entity.OsaamisenTunnistusStatus;
+import fi.okm.jod.yksilo.event.OsaamisetTunnistusEvent;
+import fi.okm.jod.yksilo.event.OsaamisetTunnistusEventHandler;
+import fi.okm.jod.yksilo.repository.KoulutusRepository;
+import fi.okm.jod.yksilo.testutil.TestUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+@SqlConfig(separator = ";;;")
+@Sql(scripts = {"/data/mock-tunnistus.sql", "/schema.sql"})
+@AutoConfigureMockMvc
+class KoulutusKokonaisuusControllerTestIT implements IntegrationTest {
+
+  @Container @ServiceConnection
+  private static final GenericContainer<?> REDIS_CONTAINER = TestUtil.createRedisContainer();
+
+  @Container @ServiceConnection
+  private static final PostgreSQLContainer<?> POSTGRES_SQL_CONTAINER =
+      TestUtil.createPostgresSQLContainer();
+
+  @MockitoBean private OsaamisetTunnistusEventHandler eventHandler;
+
+  @Autowired private KoulutusRepository koulutusRepository;
+
+  @Autowired private MockMvc mockMvc;
+
+  @WithUserDetails("test")
+  @Test
+  void addMany() throws Exception {
+    var payload =
+        """
+            [
+              {
+                "id": null,
+                "nimi": {"fi": "Testi nimi", "sv": "Test namn"},
+                "koulutukset": [
+                  {"id": null, "nimi": {"fi": "Koulutus 1", "sv": "Utbildning 1"}},
+                  {"id": null, "nimi": {"fi": "Koulutus 2", "sv": "Utbildning 2"}, "osasuoritukset": ["Kasvu, kehitys ja oppiminen (AVOIN YO)"]}
+                ]
+              }
+            ]
+            """;
+
+    mockMvc
+        .perform(
+            post("/api/profiili/koulutuskokonaisuudet/tuonti")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(2));
+
+    var eventCaptor = ArgumentCaptor.forClass(OsaamisetTunnistusEvent.class);
+    verify(eventHandler, timeout(5_000)).handleOsaamisetTunnistusEvent(eventCaptor.capture());
+    var osaamisetTunnistusEvent = eventCaptor.getValue();
+    var eventJodUser = osaamisetTunnistusEvent.jodUser();
+    assertNotNull(eventJodUser);
+    var eventKoulutukset = osaamisetTunnistusEvent.koulutukset();
+    Assertions.assertEquals(2, eventKoulutukset.size());
+    for (var koulutus : eventKoulutukset) {
+      if (koulutus.getNimi().get(Kieli.FI).equals("Koulutus 1")) {
+        assertNull(
+            koulutus.getOsasuoritukset(),
+            "Should not have any osasuoritukset, as they were not passed.");
+      } else {
+        assertNotNull(
+            koulutus.getOsasuoritukset(),
+            "Should have osasuoritukset, as they were passed. These are temporary in the event only.");
+      }
+    }
+
+    var koulutukset =
+        koulutusRepository.findAllById(eventKoulutukset.stream().map(Koulutus::getId).toList());
+    for (var koulutus : koulutukset) {
+      assertNull(koulutus.getOsasuoritukset(), "These should not been saved to DB.");
+      assertEquals(OsaamisenTunnistusStatus.WAIT, koulutus.getOsaamisenTunnistusStatus());
+    }
+  }
+}

--- a/src/test/java/fi/okm/jod/yksilo/errorhandler/ErrorHandlingTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/errorhandler/ErrorHandlingTest.java
@@ -12,7 +12,9 @@ package fi.okm.jod.yksilo.errorhandler;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.okm.jod.yksilo.IntegrationTest;
 import fi.okm.jod.yksilo.errorhandler.ErrorInfo.ErrorCode;
+import fi.okm.jod.yksilo.testutil.TestUtil;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -22,8 +24,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.HttpStatus;
@@ -32,24 +32,19 @@ import org.springframework.web.client.RestClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Testcontainers
 @Slf4j
-class ErrorHandlingTest {
+class ErrorHandlingTest implements IntegrationTest {
+
+  @Container @ServiceConnection
+  private static final GenericContainer<?> REDIS_CONTAINER = TestUtil.createRedisContainer();
+
+  @Container @ServiceConnection
+  private static final PostgreSQLContainer<?> POSTGRES_SQL_CONTAINER =
+      TestUtil.createPostgresSQLContainer();
 
   @LocalServerPort private int port;
-  @Autowired ObjectMapper mapper;
-
-  @Container @ServiceConnection
-  static GenericContainer<?> redisContainer =
-      new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
-
-  @Container @ServiceConnection
-  static PostgreSQLContainer<?> postgreSQLContainer =
-      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"));
+  @Autowired private ObjectMapper mapper;
 
   @Test
   void invalidRequestShouldReturnErrorInfo() throws IOException {

--- a/src/test/java/fi/okm/jod/yksilo/event/OsaamisetTunnistusEventHandlerTestIT.java
+++ b/src/test/java/fi/okm/jod/yksilo/event/OsaamisetTunnistusEventHandlerTestIT.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fi.okm.jod.yksilo.IntegrationTest;
+import fi.okm.jod.yksilo.domain.Kieli;
+import fi.okm.jod.yksilo.domain.LocalizedString;
+import fi.okm.jod.yksilo.entity.Koulutus;
+import fi.okm.jod.yksilo.entity.KoulutusKokonaisuus;
+import fi.okm.jod.yksilo.entity.OsaamisenTunnistusStatus;
+import fi.okm.jod.yksilo.entity.Yksilo;
+import fi.okm.jod.yksilo.service.inference.InferenceService;
+import fi.okm.jod.yksilo.testutil.TestJodUser;
+import fi.okm.jod.yksilo.testutil.TestUtil;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+@TestPropertySource(
+    properties = "jod.ai-tunnistus.osaamiset.endpoint=http://mylocalhost/invocations")
+@Sql(value = "/data/osaaminen.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+class OsaamisetTunnistusEventHandlerTestIT implements IntegrationTest {
+
+  private static final String ENDPOINT_URL = "http://mylocalhost/invocations";
+
+  @Container @ServiceConnection
+  private static final PostgreSQLContainer<?> POSTGRES_CONTAINER =
+      TestUtil.createPostgresSQLContainer();
+
+  @Autowired private OsaamisetTunnistusEventHandler eventHandler;
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @PersistenceContext private EntityManager entityManager;
+
+  @MockitoBean
+  private InferenceService<
+          OsaamisetTunnistusEventHandler.SageMakerRequest,
+          OsaamisetTunnistusEventHandler.SageMakerResponse>
+      inferenceService;
+
+  private TransactionTemplate transactionTemplate;
+  private TestJodUser user;
+  private List<Koulutus> koulutukset;
+
+  @BeforeEach
+  void setUp() {
+    transactionTemplate = new TransactionTemplate(transactionManager);
+    transactionTemplate.execute(
+        status -> {
+          var yksiloUser = new Yksilo(UUID.randomUUID());
+          entityManager.persist(yksiloUser);
+          user = new TestJodUser(yksiloUser.getId());
+
+          var yksilo = entityManager.find(Yksilo.class, user.getId());
+          var kokonaisuus = createKoulutusKokonaisuus(yksilo);
+
+          var koulutus1 = new Koulutus(kokonaisuus);
+          koulutus1.setNimi(new LocalizedString(Map.of(Kieli.FI, "Koulutus 1")));
+          koulutus1.setAlkuPvm(LocalDate.of(2023, 1, 1));
+          koulutus1.setLoppuPvm(LocalDate.of(2023, 12, 31));
+          koulutus1.setOsaamisenTunnistusStatus(OsaamisenTunnistusStatus.WAIT);
+          entityManager.persist(koulutus1);
+
+          var koulutus2 = new Koulutus(kokonaisuus);
+          koulutus2.setNimi(new LocalizedString(Map.of(Kieli.FI, "Koulutus 2")));
+          koulutus2.setAlkuPvm(LocalDate.of(2025, 1, 1));
+          koulutus2.setOsaamisenTunnistusStatus(OsaamisenTunnistusStatus.WAIT);
+          entityManager.persist(koulutus2);
+
+          koulutukset = Arrays.asList(koulutus1, koulutus2);
+
+          return null;
+        });
+  }
+
+  private KoulutusKokonaisuus createKoulutusKokonaisuus(Yksilo yksilo) {
+    var kokonaisuus =
+        new KoulutusKokonaisuus(yksilo, new LocalizedString(Map.of(Kieli.FI, "Test Kokonaisuus")));
+    entityManager.persist(kokonaisuus);
+    return kokonaisuus;
+  }
+
+  @Test
+  void shouldSuccessfullyProcessOsaamisetTunnistusEvent()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    var osaaminen1 = "urn:osaaminen1";
+    var osaaminen2 = "urn:osaaminen2";
+
+    var koulutus1 = koulutukset.getFirst();
+    var osasuoritukset =
+        Set.of(
+            "Kasvu, kehitys ja oppiminen (AVOIN YO)",
+            "Opetus ja kasvatuksellinen vuorovaikutus (AVOIN YO)");
+    koulutus1.setOsasuoritukset(osasuoritukset);
+
+    var sageMakerRequest =
+        new OsaamisetTunnistusEventHandler.SageMakerRequest(
+            koulutus1.getId(), koulutus1.getNimi().get(Kieli.FI), osasuoritukset);
+
+    var sageMakerResponse =
+        new OsaamisetTunnistusEventHandler.SageMakerResponse(
+            koulutus1.getId(), Set.of(URI.create(osaaminen1), URI.create(osaaminen2)));
+
+    when(inferenceService.infer(
+            ENDPOINT_URL, sageMakerRequest, new ParameterizedTypeReference<>() {}))
+        .thenReturn(sageMakerResponse);
+
+    var result =
+        eventHandler.handleOsaamisetTunnistusEvent(
+            new OsaamisetTunnistusEvent(user, List.of(koulutus1)));
+    result.get(5, TimeUnit.SECONDS); // Wait for execution to be completed.
+
+    verifyOsaamisetUpdated(koulutus1, sageMakerResponse.osaamiset());
+    verify(inferenceService)
+        .infer(ENDPOINT_URL, sageMakerRequest, new ParameterizedTypeReference<>() {});
+  }
+
+  private void verifyOsaamisetUpdated(Koulutus koulutus, Set<URI> expectedOsaamisetUris) {
+    transactionTemplate.execute(
+        status -> {
+          var updatedKoulutus = entityManager.find(Koulutus.class, koulutus.getId());
+
+          assertNotNull(updatedKoulutus, "Updated koulutus should not be null");
+          assertEquals(
+              OsaamisenTunnistusStatus.DONE, updatedKoulutus.getOsaamisenTunnistusStatus());
+
+          var actualUris =
+              updatedKoulutus.getOsaamiset().stream()
+                  .map(o -> o.getOsaaminen().getUri())
+                  .collect(Collectors.toSet());
+
+          assertNotNull(
+              expectedOsaamisetUris,
+              "Expected URIs should exist for koulutus ID: " + koulutus.getId());
+          assertTrue(
+              actualUris.containsAll(expectedOsaamisetUris),
+              "Osaamiset URIs should match for koulutus ID: " + koulutus.getId());
+          return null;
+        });
+  }
+
+  @Test
+  void shouldHandleApiErrorsGracefully()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    when(inferenceService.infer(
+            eq(ENDPOINT_URL),
+            any(OsaamisetTunnistusEventHandler.SageMakerRequest.class),
+            eq(
+                new ParameterizedTypeReference<
+                    OsaamisetTunnistusEventHandler.SageMakerResponse>() {})))
+        .thenThrow(new RuntimeException("Internal Server error"));
+
+    var result =
+        eventHandler.handleOsaamisetTunnistusEvent(new OsaamisetTunnistusEvent(user, koulutukset));
+    result.get(5, TimeUnit.SECONDS); // Wait for execution to be completed.
+
+    verify(inferenceService, times(koulutukset.size()))
+        .infer(
+            eq(ENDPOINT_URL),
+            any(OsaamisetTunnistusEventHandler.SageMakerRequest.class),
+            eq(
+                new ParameterizedTypeReference<
+                    OsaamisetTunnistusEventHandler.SageMakerResponse>() {}));
+    verifyKoulutusStatuses(koulutukset, OsaamisenTunnistusStatus.FAIL);
+  }
+
+  private void verifyKoulutusStatuses(
+      List<Koulutus> koulutukset, OsaamisenTunnistusStatus expectedStatus) {
+    transactionTemplate.execute(
+        status -> {
+          for (Koulutus koulutus : koulutukset) {
+            var updatedKoulutus = entityManager.find(Koulutus.class, koulutus.getId());
+            assertNotNull(updatedKoulutus, "Koulutus should exist");
+            assertEquals(
+                expectedStatus,
+                updatedKoulutus.getOsaamisenTunnistusStatus(),
+                "Koulutus should have status: " + expectedStatus);
+          }
+          return null;
+        });
+  }
+}

--- a/src/test/java/fi/okm/jod/yksilo/service/AbstractServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/AbstractServiceTest.java
@@ -11,6 +11,7 @@ package fi.okm.jod.yksilo.service;
 
 import fi.okm.jod.yksilo.entity.Yksilo;
 import fi.okm.jod.yksilo.testutil.TestJodUser;
+import fi.okm.jod.yksilo.testutil.TestUtil;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +23,6 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @DataJpaTest(showSql = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -30,10 +30,7 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class AbstractServiceTest {
 
   @Container @ServiceConnection
-  static PostgreSQLContainer<?> postgreSQLContainer =
-      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
-          .withEnv("LANG", "en_US.UTF-8")
-          .withEnv("LC_ALL", "en_US.UTF-8");
+  static PostgreSQLContainer<?> postgreSQLContainer = TestUtil.createPostgresSQLContainer();
 
   @Autowired protected TestEntityManager entityManager;
   protected TestJodUser user;

--- a/src/test/java/fi/okm/jod/yksilo/service/AmmattiServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/AmmattiServiceTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.benmanes.caffeine.cache.Ticker;
 import fi.okm.jod.yksilo.repository.AmmattiRepository;
+import fi.okm.jod.yksilo.testutil.TestUtil;
 import java.net.URI;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +34,6 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @DataJpaTest(showSql = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -50,10 +50,7 @@ class AmmattiServiceTest {
   private TransactionTemplate transactionTemplate;
 
   @Container @ServiceConnection
-  static PostgreSQLContainer<?> postgreSQLContainer =
-      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
-          .withEnv("LANG", "en_US.UTF-8")
-          .withEnv("LC_ALL", "en_US.UTF-8");
+  static PostgreSQLContainer<?> postgreSQLContainer = TestUtil.createPostgresSQLContainer();
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/fi/okm/jod/yksilo/service/KoulutusKokonaisuusServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/KoulutusKokonaisuusServiceTest.java
@@ -16,13 +16,12 @@ import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusDto;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusKokonaisuusDto;
 import fi.okm.jod.yksilo.dto.profiili.KoulutusKokonaisuusUpdateDto;
-import fi.okm.jod.yksilo.repository.KoulutusKokonaisuusRepository;
-import fi.okm.jod.yksilo.repository.YksilonOsaaminenRepository;
 import fi.okm.jod.yksilo.service.profiili.KoulutusKokonaisuusService;
 import fi.okm.jod.yksilo.service.profiili.KoulutusService;
 import fi.okm.jod.yksilo.service.profiili.YksilonOsaaminenService;
 import java.net.URI;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,14 +33,15 @@ import org.springframework.test.context.jdbc.Sql;
 class KoulutusKokonaisuusServiceTest extends AbstractServiceTest {
 
   @Autowired KoulutusKokonaisuusService service;
-  @Autowired KoulutusKokonaisuusRepository toimenkuvat;
-  @Autowired YksilonOsaaminenRepository osaaminen;
 
   @Test
   void shouldAddKoulutusKokonaisuus() {
     assertDoesNotThrow(
         () -> {
-          var id = service.add(user, new KoulutusKokonaisuusDto(null, ls(Kieli.FI, "nimi"), null));
+          var id =
+              service.add(
+                  user,
+                  new KoulutusKokonaisuusDto(null, ls(Kieli.FI, "nimi"), Collections.emptySet()));
           entityManager.flush();
 
           var updatedNimi = ls(Kieli.SV, "namn");
@@ -73,7 +73,10 @@ class KoulutusKokonaisuusServiceTest extends AbstractServiceTest {
                                 ls(Kieli.FI, "kuvaus"),
                                 LocalDate.now(),
                                 null,
-                                Set.of(URI.create("urn:osaaminen1")))
+                                Set.of(URI.create("urn:osaaminen1")),
+                                null,
+                                null,
+                                null)
                           })));
 
           simulateCommit();

--- a/src/test/java/fi/okm/jod/yksilo/service/MahdollisuusImportTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/MahdollisuusImportTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fi.okm.jod.yksilo.domain.KoulutusmahdollisuusTyyppi;
 import fi.okm.jod.yksilo.domain.TyomahdollisuusAineisto;
+import fi.okm.jod.yksilo.testutil.TestUtil;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,6 @@ import org.springframework.test.context.jdbc.SqlConfig;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @DataJpaTest(showSql = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -41,10 +41,7 @@ import org.testcontainers.utility.DockerImageName;
 public class MahdollisuusImportTest {
 
   @Container @ServiceConnection
-  static PostgreSQLContainer<?> postgreSQLContainer =
-      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
-          .withEnv("LANG", "en_US.UTF-8")
-          .withEnv("LC_ALL", "en_US.UTF-8");
+  static PostgreSQLContainer<?> postgreSQLContainer = TestUtil.createPostgresSQLContainer();
 
   @Autowired protected TestEntityManager entityManager;
 

--- a/src/test/java/fi/okm/jod/yksilo/service/koski/KoskiServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/koski/KoskiServiceTest.java
@@ -12,6 +12,7 @@ package fi.okm.jod.yksilo.service.koski;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,23 +38,59 @@ class KoskiServiceTest {
     var content = TestUtil.getContentFromFile("koski-response.json", this.getClass());
     var koskiData = koskiService.getKoulutusData(objectMapper.readTree(content));
 
-    assertEquals(1, koskiData.size());
+    assertEquals(2, koskiData.size());
     var koulutusDto = koskiData.getFirst();
     assertNull(koulutusDto.id());
-    assertEquals("Jyväskylän normaalikoulu", koulutusDto.nimi().get(Kieli.FI));
-    assertEquals("Jyväskylän normaalikoulu", koulutusDto.nimi().get(Kieli.EN));
-    assertEquals("Jyväskylän normaalikoulu", koulutusDto.nimi().get(Kieli.SV));
-    assertEquals(
-        "Aikuisten perusopetuksen oppimäärän alkuvaihe", koulutusDto.kuvaus().get(Kieli.FI));
-    assertEquals(
-        "Introductory phase to basic education for adults  syllabus",
-        koulutusDto.kuvaus().get(Kieli.EN));
-    assertEquals(
-        "Inledningsskedet i den grundläggande utbildningen för vuxna",
-        koulutusDto.kuvaus().get(Kieli.SV));
-    assertEquals(LocalDate.of(2006, 1, 1), koulutusDto.alkuPvm());
-    assertNull(koulutusDto.loppuPvm());
+    assertLocalizedString(
+        koulutusDto.nimi(),
+        "Itä-Suomen yliopisto",
+        "Östra Finlands Universitet",
+        "University of Eastern Finland");
+    assertLocalizedString(
+        koulutusDto.kuvaus(),
+        "Lääketieteen lisensiaatti",
+        "Medicine licentiat",
+        "Licentiate of Medicine");
+    assertEquals(LocalDate.of(2018, 8, 1), koulutusDto.alkuPvm());
+    assertEquals(LocalDate.of(2026, 7, 31), koulutusDto.loppuPvm());
     assertNull(koulutusDto.osaamiset());
+    assertEquals(71, koulutusDto.osasuoritukset().size());
+
+    var koulutusDto2 = koskiData.get(1);
+    assertNull(koulutusDto2.id());
+    assertLocalizedString(
+        koulutusDto2.nimi(),
+        "Ylioppilastutkintolautakunta",
+        "Studentexamensnämnden",
+        "The Matriculation Examination Board");
+    assertLocalizedString(
+        koulutusDto2.kuvaus(), "Ylioppilastutkinto", "Studentexamen", "Matriculation Examination");
+    assertNull(koulutusDto2.alkuPvm());
+    assertNull(koulutusDto2.loppuPvm());
+    assertNull(koulutusDto2.osaamiset());
+    assertTrue(koulutusDto2.osasuoritukset().isEmpty());
+  }
+
+  private static void assertLocalizedString(
+      LocalizedString localizedString,
+      String expectedFinnish,
+      String expectedSwedish,
+      String expectedEnglish) {
+    if (expectedFinnish == null) {
+      assertNull(localizedString.get(Kieli.FI));
+    } else {
+      assertEquals(expectedFinnish, localizedString.get(Kieli.FI));
+    }
+    if (expectedSwedish == null) {
+      assertNull(localizedString.get(Kieli.SV));
+    } else {
+      assertEquals(expectedSwedish, localizedString.get(Kieli.SV));
+    }
+    if (expectedEnglish == null) {
+      assertNull(localizedString.get(Kieli.EN));
+    } else {
+      assertEquals(expectedEnglish, localizedString.get(Kieli.EN));
+    }
   }
 
   @Test
@@ -66,7 +103,6 @@ class KoskiServiceTest {
 
     assertNotNull(result);
     assertEquals(2, result.asMap().size());
-    assertEquals("Avoimen opinnot: Lisätietoja", result.get(Kieli.FI));
-    assertEquals("Öppna studier", result.get(Kieli.SV));
+    assertLocalizedString(result, "Avoimen opinnot: Lisätietoja", "Öppna studier", null);
   }
 }

--- a/src/test/java/fi/okm/jod/yksilo/testutil/TestUtil.java
+++ b/src/test/java/fi/okm/jod/yksilo/testutil/TestUtil.java
@@ -9,12 +9,15 @@
 
 package fi.okm.jod.yksilo.testutil;
 
-import fi.okm.jod.yksilo.domain.JodUser;
 import java.nio.charset.StandardCharsets;
-import org.springframework.security.authentication.TestingAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class TestUtil {
+
+  private static final String POSTGRES_VERSION = "postgres:16-alpine";
+  private static final String REDIS_VERSION = "redis:7-alpine";
 
   private TestUtil() {
     // Utility class.
@@ -32,9 +35,13 @@ public class TestUtil {
     }
   }
 
-  public static void authenticateUser(JodUser jodUser) {
-    var context = SecurityContextHolder.createEmptyContext();
-    context.setAuthentication(new TestingAuthenticationToken(jodUser, null));
-    SecurityContextHolder.setContext(context);
+  public static PostgreSQLContainer<?> createPostgresSQLContainer() {
+    return new PostgreSQLContainer<>(TestUtil.POSTGRES_VERSION)
+        .withEnv("LANG", "en_US.UTF-8")
+        .withEnv("LC_ALL", "en_US.UTF-8");
+  }
+
+  public static GenericContainer<?> createRedisContainer() {
+    return new GenericContainer<>(DockerImageName.parse(REDIS_VERSION)).withExposedPorts(6379);
   }
 }

--- a/src/test/resources/fi/okm/jod/yksilo/service/koski/koski-response.json
+++ b/src/test/resources/fi/okm/jod/yksilo/service/koski/koski-response.json
@@ -1,80 +1,256 @@
 {
   "henkilö": {
-    "hetu": "241001B765F"
+    "hetu": "010280-952L"
   },
   "opiskeluoikeudet": [
     {
-      "oid": "1.2.246.562.15.93520514022",
-      "versionumero": 1,
-      "aikaleima": "2025-02-03T13:56:53.044526",
-      "oppilaitos": {
-        "oid": "1.2.246.562.10.14613773812",
-        "oppilaitosnumero": {
-          "koodiarvo": "00204",
+      "lähdejärjestelmänId": {
+        "id": "60232459",
+        "lähdejärjestelmä": {
+          "koodiarvo": "virta",
           "nimi": {
-            "fi": "Jyväskylän normaalikoulu",
-            "sv": "Jyväskylän normaalikoulu",
-            "en": "Jyväskylän normaalikoulu"
+            "fi": "virta"
+          },
+          "koodistoUri": "lahdejarjestelma",
+          "koodistoVersio": 1
+        }
+      },
+      "oppilaitos": {
+        "oid": "1.2.246.562.10.38515028629",
+        "oppilaitosnumero": {
+          "koodiarvo": "10088",
+          "nimi": {
+            "fi": "Itä-Suomen yliopisto",
+            "sv": "Östra Finlands Universitet",
+            "en": "University of Eastern Finland"
           },
           "lyhytNimi": {
-            "fi": "Jyväskylän normaalikoulu",
-            "sv": "Jyväskylän normaalikoulu",
-            "en": "Jyväskylän normaalikoulu"
+            "fi": "Itä-Suomen yliopisto",
+            "sv": "Östra Finlands Universitet",
+            "en": "University of Eastern Finland"
           },
-          "koodistoUri": "oppilaitosnumero"
+          "koodistoUri": "oppilaitosnumero",
+          "koodistoVersio": 1
         },
         "nimi": {
-          "fi": "Jyväskylän normaalikoulu",
-          "sv": "Jyväskylän normaalikoulu",
-          "en": "Jyväskylän normaalikoulu"
+          "fi": "Itä-Suomen yliopisto",
+          "sv": "Östra Finlands Universitet",
+          "en": "University of Eastern Finland"
         },
         "kotipaikka": {
-          "koodiarvo": "179",
+          "koodiarvo": "167",
           "nimi": {
-            "fi": "Jyväskylä",
-            "sv": "Jyväskylä"
+            "fi": "Joensuu",
+            "sv": "Joensuu"
           },
-          "koodistoUri": "kunta"
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
         }
       },
-      "koulutustoimija": {
-        "oid": "1.2.246.562.10.77055527103",
-        "nimi": {
-          "fi": "Jyväskylän yliopisto"
-        },
-        "yTunnus": "0245894-7",
-        "kotipaikka": {
-          "koodiarvo": "179",
-          "nimi": {
-            "fi": "Jyväskylä",
-            "sv": "Jyväskylä"
-          },
-          "koodistoUri": "kunta"
-        }
-      },
+      "päättymispäivä": "2026-07-31",
       "tila": {
         "opiskeluoikeusjaksot": [
           {
-            "alku": "2006-01-01",
-            "tila": {
-              "koodiarvo": "lasna",
-              "nimi": {
-                "fi": "Läsnä",
-                "sv": "Närvarande",
-                "en": "Present"
-              },
-              "koodistoUri": "koskiopiskeluoikeudentila",
-              "koodistoVersio": 1
+            "alku": "2018-08-01",
+            "nimi": {
+              "fi": "Lääketieteen koulutusohjelma",
+              "en": "Medicine"
             },
-            "opintojenRahoitus": {
-              "koodiarvo": "6",
+            "tila": {
+              "koodiarvo": "1",
               "nimi": {
-                "fi": "Muuta kautta rahoitettu",
-                "sv": "Finansierad på annat sätt",
-                "en": "Funded by other means"
+                "fi": "aktiivinen",
+                "sv": "aktiv",
+                "en": "active"
               },
-              "koodistoUri": "opintojenrahoitus",
+              "koodistoUri": "virtaopiskeluoikeudentila",
               "koodistoVersio": 1
+            }
+          }
+        ]
+      },
+      "lisätiedot": {
+        "virtaOpiskeluoikeudenTyyppi": {
+          "koodiarvo": "4",
+          "nimi": {
+            "fi": "Ylempi korkeakoulututkinto",
+            "sv": "Högre högskoleexamen"
+          },
+          "koodistoUri": "virtaopiskeluoikeudentyyppi",
+          "koodistoVersio": 1
+        },
+        "lukukausiIlmoittautuminen": {
+          "ilmoittautumisjaksot": [
+            {
+              "alku": "2018-08-01",
+              "loppu": "2018-12-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2019-01-01",
+              "loppu": "2019-07-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2019-08-01",
+              "loppu": "2019-12-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2020-01-01",
+              "loppu": "2020-07-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2020-08-01",
+              "loppu": "2020-12-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2021-01-01",
+              "loppu": "2021-07-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2021-08-01",
+              "loppu": "2021-12-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2022-01-01",
+              "loppu": "2022-07-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2022-08-01",
+              "loppu": "2022-12-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2023-01-01",
+              "loppu": "2023-07-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2023-08-01",
+              "loppu": "2023-12-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "alku": "2024-01-01",
+              "loppu": "2024-07-31",
+              "tila": {
+                "koodiarvo": "1",
+                "nimi": {
+                  "fi": "Läsnä",
+                  "sv": "Närvarande"
+                },
+                "koodistoUri": "virtalukukausiilmtila",
+                "koodistoVersio": 1
+              }
+            }
+          ]
+        },
+        "koulutuskuntaJaksot": [
+          {
+            "alku": "2018-08-01",
+            "loppu": "2026-07-31",
+            "koulutuskunta": {
+              "koodiarvo": "297",
+              "nimi": {
+                "fi": "Kuopio",
+                "sv": "Kuopio"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
             }
           }
         ]
@@ -82,80 +258,9871 @@
       "suoritukset": [
         {
           "koulutusmoduuli": {
-            "perusteenDiaarinumero": "19/011/2015",
             "tunniste": {
-              "koodiarvo": "aikuistenperusopetuksenoppimaaranalkuvaihe",
+              "koodiarvo": "772101",
               "nimi": {
-                "fi": "Aikuisten perusopetuksen oppimäärän alkuvaihe",
-                "sv": "Inledningsskedet i den grundläggande utbildningen för vuxna",
-                "en": "Introductory phase to basic education for adults  syllabus"
-              },
-              "koodistoUri": "suorituksentyyppi",
-              "koodistoVersio": 1
-            }
-          },
-          "luokka": "6C",
-          "toimipiste": {
-            "oid": "1.2.246.562.10.14613773812",
-            "oppilaitosnumero": {
-              "koodiarvo": "00204",
-              "nimi": {
-                "fi": "Jyväskylän normaalikoulu",
-                "sv": "Jyväskylän normaalikoulu",
-                "en": "Jyväskylän normaalikoulu"
+                "fi": "Lääketieteen lisensiaatti",
+                "sv": "Medicine licentiat",
+                "en": "Licentiate of Medicine"
               },
               "lyhytNimi": {
-                "fi": "Jyväskylän normaalikoulu",
-                "sv": "Jyväskylän normaalikoulu",
-                "en": "Jyväskylän normaalikoulu"
+                "fi": "Lääketieteen lisensiaatti",
+                "sv": "Medicine licentiat",
+                "en": "Licentiate of Medicine"
               },
-              "koodistoUri": "oppilaitosnumero"
+              "koodistoUri": "koulutus",
+              "koodistoVersio": 12
             },
-            "nimi": {
-              "fi": "Jyväskylän normaalikoulu",
-              "sv": "Jyväskylän normaalikoulu",
-              "en": "Jyväskylän normaalikoulu"
-            },
-            "kotipaikka": {
-              "koodiarvo": "179",
-              "nimi": {
-                "fi": "Jyväskylä",
-                "sv": "Jyväskylä"
-              },
-              "koodistoUri": "kunta"
+            "virtaNimi": {
+              "fi": "Lääketieteen koulutusohjelma",
+              "en": "Medicine"
             }
           },
-          "suoritustapa": {
-            "koodiarvo": "erityinentutkinto",
+          "toimipiste": {
+            "oid": "1.2.246.562.10.38515028629",
+            "oppilaitosnumero": {
+              "koodiarvo": "10088",
+              "nimi": {
+                "fi": "Itä-Suomen yliopisto",
+                "sv": "Östra Finlands Universitet",
+                "en": "University of Eastern Finland"
+              },
+              "lyhytNimi": {
+                "fi": "Itä-Suomen yliopisto",
+                "sv": "Östra Finlands Universitet",
+                "en": "University of Eastern Finland"
+              },
+              "koodistoUri": "oppilaitosnumero",
+              "koodistoVersio": 1
+            },
             "nimi": {
-              "fi": "Erityinen tutkinto",
-              "sv": "Särskild examen",
-              "en": "Separate basic education examination"
+              "fi": "Itä-Suomen yliopisto",
+              "sv": "Östra Finlands Universitet",
+              "en": "University of Eastern Finland"
             },
-            "koodistoUri": "perusopetuksensuoritustapa",
-            "koodistoVersio": 1
+            "kotipaikka": {
+              "koodiarvo": "167",
+              "nimi": {
+                "fi": "Joensuu",
+                "sv": "Joensuu"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
           },
-          "suorituskieli": {
-            "koodiarvo": "FI",
-            "nimi": {
-              "fi": "suomi",
-              "sv": "finska",
-              "en": "Finnish"
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 8013701",
+                  "nimi": {
+                    "fi": "English Academic Reading Skills for Medicine"
+                  }
+                },
+                "nimi": {
+                  "fi": "English Academic Reading Skills for Medicine"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2018-11-28",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2018-11-28",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "EN",
+                "nimi": {
+                  "fi": "englanti",
+                  "sv": "engelska",
+                  "en": "English"
+                },
+                "lyhytNimi": {
+                  "fi": "englanti",
+                  "sv": "engelska",
+                  "en": "English"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
             },
-            "lyhytNimi": {
-              "fi": "suomi",
-              "sv": "finska",
-              "en": "Finnish"
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421601",
+                  "nimi": {
+                    "fi": "Solun ja kudoksen rakenne ja toiminta"
+                  }
+                },
+                "nimi": {
+                  "fi": "Solun ja kudoksen rakenne ja toiminta"
+                },
+                "laajuus": {
+                  "arvo": 9.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2018-11-16",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2018-11-16",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
             },
-            "koodistoUri": "kieli",
-            "koodistoVersio": 1
-          },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421605",
+                  "nimi": {
+                    "fi": "Tuki- ja liikuntaelimistö"
+                  }
+                },
+                "nimi": {
+                  "fi": "Tuki- ja liikuntaelimistö"
+                },
+                "laajuus": {
+                  "arvo": 6.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-02-18",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-02-18",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 5426101",
+                  "nimi": {
+                    "fi": "Johdatus sosiaali- ja terveyspalvelujärjestelmään"
+                  }
+                },
+                "nimi": {
+                  "fi": "Johdatus sosiaali- ja terveyspalvelujärjestelmään"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-04-15",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-04-15",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424302",
+                  "nimi": {
+                    "fi": "Säteily ja sen turvallinen käyttö lääketieteessä"
+                  }
+                },
+                "nimi": {
+                  "fi": "Säteily ja sen turvallinen käyttö lääketieteessä"
+                },
+                "laajuus": {
+                  "arvo": 1.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-11-03",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-11-03",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422503",
+                  "nimi": {
+                    "fi": "Kliininen mikrobiologia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kliininen mikrobiologia"
+                },
+                "laajuus": {
+                  "arvo": 6.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-02-19",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-02-19",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421502",
+                  "nimi": {
+                    "fi": "Fysiikkaa lääketiedettä opiskeleville"
+                  }
+                },
+                "nimi": {
+                  "fi": "Fysiikkaa lääketiedettä opiskeleville"
+                },
+                "laajuus": {
+                  "arvo": 2.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2018-11-30",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2018-11-30",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4423101",
+                  "nimi": {
+                    "fi": "Sisätautioppi kardiologia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Sisätautioppi kardiologia"
+                },
+                "laajuus": {
+                  "arvo": 5.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-12-09",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-12-09",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4425050-1002",
+                  "nimi": {
+                    "fi": "Fysiatria"
+                  }
+                },
+                "nimi": {
+                  "fi": "Fysiatria"
+                },
+                "laajuus": {
+                  "arvo": 3.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-10-15",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-10-15",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4426201-1001",
+                  "nimi": {
+                    "fi": "Kirurgia seminaarit"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kirurgia seminaarit"
+                },
+                "laajuus": {
+                  "arvo": 3.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-03-07",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-03-07",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424500-3001",
+                  "nimi": {
+                    "fi": "Naistentaudit ja synnytysoppi"
+                  }
+                },
+                "nimi": {
+                  "fi": "Naistentaudit ja synnytysoppi"
+                },
+                "laajuus": {
+                  "arvo": 13.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "1",
+                    "nimi": {
+                      "fi": "1",
+                      "sv": "1"
+                    },
+                    "lyhytNimi": {
+                      "fi": "1",
+                      "sv": "1"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-12-16",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-12-16",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 TL00BX75-3002",
+                  "nimi": {
+                    "fi": "Lastentaudit ja lastenneurologia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Lastentaudit ja lastenneurologia"
+                },
+                "laajuus": {
+                  "arvo": 14.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-10-14",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-10-14",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 TL00BX93-3001",
+                  "nimi": {
+                    "fi": "Palliatiivinen lääketiede, LT5"
+                  }
+                },
+                "nimi": {
+                  "fi": "Palliatiivinen lääketiede, LT5"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-05-12",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-05-12",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4427501",
+                  "nimi": {
+                    "fi": "Hätäensiapu"
+                  }
+                },
+                "nimi": {
+                  "fi": "Hätäensiapu"
+                },
+                "laajuus": {
+                  "arvo": 1.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-05-22",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-05-22",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4423602",
+                  "nimi": {
+                    "fi": "Potilas-lääkärisuhde"
+                  }
+                },
+                "nimi": {
+                  "fi": "Potilas-lääkärisuhde"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-09-04",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-09-04",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421603",
+                  "nimi": {
+                    "fi": "Johdanto ihmisen biologiaan"
+                  }
+                },
+                "nimi": {
+                  "fi": "Johdanto ihmisen biologiaan"
+                },
+                "laajuus": {
+                  "arvo": 1.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2018-10-15",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2018-10-15",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421606",
+                  "nimi": {
+                    "fi": "Verenkierto, hengitys ja nestetasapaino"
+                  }
+                },
+                "nimi": {
+                  "fi": "Verenkierto, hengitys ja nestetasapaino"
+                },
+                "laajuus": {
+                  "arvo": 9.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-04-10",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-04-10",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4218801",
+                  "nimi": {
+                    "fi": "Perusfarmakologia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Perusfarmakologia"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-04-06",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-04-06",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424301",
+                  "nimi": {
+                    "fi": "Kliininen radiologia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kliininen radiologia"
+                },
+                "laajuus": {
+                  "arvo": 4.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-04-23",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-04-23",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422407",
+                  "nimi": {
+                    "fi": "Ympäristöterveydenhuollon perusteet"
+                  }
+                },
+                "nimi": {
+                  "fi": "Ympäristöterveydenhuollon perusteet"
+                },
+                "laajuus": {
+                  "arvo": 1.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-02-24",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-02-24",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422611",
+                  "nimi": {
+                    "fi": "Elimistön puolustusjärjestelmät"
+                  }
+                },
+                "nimi": {
+                  "fi": "Elimistön puolustusjärjestelmät"
+                },
+                "laajuus": {
+                  "arvo": 4.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-11-25",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-11-25",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4423301",
+                  "nimi": {
+                    "fi": "Sisätautioppi endokrinologia ja hematologia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Sisätautioppi endokrinologia ja hematologia"
+                },
+                "laajuus": {
+                  "arvo": 5.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-02-26",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-02-26",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4214999",
+                  "nimi": {
+                    "fi": "Reseptioppi (lääketieteen opiskelijat)"
+                  }
+                },
+                "nimi": {
+                  "fi": "Reseptioppi (lääketieteen opiskelijat)"
+                },
+                "laajuus": {
+                  "arvo": 1.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-09-28",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-09-28",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424050-1001",
+                  "nimi": {
+                    "fi": "Johdatus yleislääketieteeseen I"
+                  }
+                },
+                "nimi": {
+                  "fi": "Johdatus yleislääketieteeseen I"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-12-01",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-12-01",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424700-1001",
+                  "nimi": {
+                    "fi": "Neurologia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Neurologia"
+                },
+                "laajuus": {
+                  "arvo": 6.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-03-06",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-03-06",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4425001-3001",
+                  "nimi": {
+                    "fi": "Johdatus yleislääketieteeseen II"
+                  }
+                },
+                "nimi": {
+                  "fi": "Johdatus yleislääketieteeseen II"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-05-26",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-05-26",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4427108",
+                  "nimi": {
+                    "fi": "Tutkimus tutuksi"
+                  }
+                },
+                "nimi": {
+                  "fi": "Tutkimus tutuksi"
+                },
+                "laajuus": {
+                  "arvo": 1.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-03-31",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-03-31",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "1008 Lääketieteen koulutusohjelma",
+                  "nimi": {
+                    "fi": "Pätevyys ll4"
+                  }
+                },
+                "nimi": {
+                  "fi": "Pätevyys ll4"
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-05-20",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-05-20",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4427107",
+                  "nimi": {
+                    "fi": "Lääketieteellinen tieto ja viestintä"
+                  }
+                },
+                "nimi": {
+                  "fi": "Lääketieteellinen tieto ja viestintä"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-04-30",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-04-30",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 5426104-3002",
+                  "nimi": {
+                    "fi": "Moniammatillinen SOTE-johtaminen"
+                  }
+                },
+                "nimi": {
+                  "fi": "Moniammatillinen SOTE-johtaminen"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-04-18",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-04-18",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 8012701B",
+                  "nimi": {
+                    "fi": "Ruotsin suullinen taito lääketieteen opiskelijoille"
+                  }
+                },
+                "nimi": {
+                  "fi": "Ruotsin suullinen taito lääketieteen opiskelijoille"
+                },
+                "laajuus": {
+                  "arvo": 1.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "TT",
+                    "nimi": {
+                      "fi": "tyydyttävät tiedot",
+                      "sv": "nöjaktiga insikter",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "TT"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-05-27",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-05-27",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421604",
+                  "nimi": {
+                    "fi": "Kehitysbiologia ja lisääntyminen"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kehitysbiologia ja lisääntyminen"
+                },
+                "laajuus": {
+                  "arvo": 5.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2018-12-13",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2018-12-13",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4423501",
+                  "nimi": {
+                    "fi": "Tautioppi"
+                  }
+                },
+                "nimi": {
+                  "fi": "Tautioppi"
+                },
+                "laajuus": {
+                  "arvo": 7.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-11-27",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-11-27",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422409",
+                  "nimi": {
+                    "fi": "Kansanterveystiede"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kansanterveystiede"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-11-14",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-11-14",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422610",
+                  "nimi": {
+                    "fi": "Lääketieteen dissektiot"
+                  }
+                },
+                "nimi": {
+                  "fi": "Lääketieteen dissektiot"
+                },
+                "laajuus": {
+                  "arvo": 6.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "1",
+                    "nimi": {
+                      "fi": "1",
+                      "sv": "1"
+                    },
+                    "lyhytNimi": {
+                      "fi": "1",
+                      "sv": "1"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-12-16",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-12-16",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4423451",
+                  "nimi": {
+                    "fi": "Sisätautioppi ryhmäopetukset, seminaarit, potilaiden tutkiminen ja päivystys"
+                  }
+                },
+                "nimi": {
+                  "fi": "Sisätautioppi ryhmäopetukset, seminaarit, potilaiden tutkiminen ja päivystys"
+                },
+                "laajuus": {
+                  "arvo": 5.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-05-25",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-05-25",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4423001",
+                  "nimi": {
+                    "fi": "Potilaan tutkiminen"
+                  }
+                },
+                "nimi": {
+                  "fi": "Potilaan tutkiminen"
+                },
+                "laajuus": {
+                  "arvo": 6.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-10-19",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-10-19",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424101-1001",
+                  "nimi": {
+                    "fi": "Geriatria"
+                  }
+                },
+                "nimi": {
+                  "fi": "Geriatria"
+                },
+                "laajuus": {
+                  "arvo": 2.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-04-11",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-04-11",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424650-1001",
+                  "nimi": {
+                    "fi": "Neurokirurgia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Neurokirurgia"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-02-22",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-02-22",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4425300-1002",
+                  "nimi": {
+                    "fi": "Terveyskeskusopetus II"
+                  }
+                },
+                "nimi": {
+                  "fi": "Terveyskeskusopetus II"
+                },
+                "laajuus": {
+                  "arvo": 1.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-03-17",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-03-17",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424600-3007",
+                  "nimi": {
+                    "fi": "Lastenpsykiatria"
+                  }
+                },
+                "nimi": {
+                  "fi": "Lastenpsykiatria"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-03-03",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-03-03",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4425400-3001",
+                  "nimi": {
+                    "fi": "Työlääketiede ja työterveyshuolto"
+                  }
+                },
+                "nimi": {
+                  "fi": "Työlääketiede ja työterveyshuolto"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-12-08",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-12-08",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4427533",
+                  "nimi": {
+                    "fi": "Covid-19"
+                  }
+                },
+                "nimi": {
+                  "fi": "Covid-19"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-05-27",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-05-27",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 KK00BN79-3005",
+                  "nimi": {
+                    "fi": "Academic and Medical English"
+                  }
+                },
+                "nimi": {
+                  "fi": "Academic and Medical English"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-04-06",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-04-06",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421602",
+                  "nimi": {
+                    "fi": "Genetiikka"
+                  }
+                },
+                "nimi": {
+                  "fi": "Genetiikka"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-05-24",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-05-24",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421607",
+                  "nimi": {
+                    "fi": "Ruoansulatus ja metabolia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Ruoansulatus ja metabolia"
+                },
+                "laajuus": {
+                  "arvo": 8.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-05-28",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-05-28",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4218804",
+                  "nimi": {
+                    "fi": "Systemaattinen farmakologia 2 lääketieteen ja hammaslääketieteen opiskelijoille"
+                  }
+                },
+                "nimi": {
+                  "fi": "Systemaattinen farmakologia 2 lääketieteen ja hammaslääketieteen opiskelijoille"
+                },
+                "laajuus": {
+                  "arvo": 4.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-05-29",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-05-29",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4423550",
+                  "nimi": {
+                    "fi": "Kliininen fysiologia ja isotooppilääketiede"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kliininen fysiologia ja isotooppilääketiede"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-05-21",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-05-21",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422504",
+                  "nimi": {
+                    "fi": "Tautiopin perusteet"
+                  }
+                },
+                "nimi": {
+                  "fi": "Tautiopin perusteet"
+                },
+                "laajuus": {
+                  "arvo": 6.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-03-31",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-03-31",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4421401",
+                  "nimi": {
+                    "fi": "Johdatus lääketieteeseen"
+                  }
+                },
+                "nimi": {
+                  "fi": "Johdatus lääketieteeseen"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2018-10-24",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2018-10-24",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4423201",
+                  "nimi": {
+                    "fi": "Sisätautioppi gastroenterologia, nefrologia ja reumatologia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Sisätautioppi gastroenterologia, nefrologia ja reumatologia"
+                },
+                "laajuus": {
+                  "arvo": 5.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-02-05",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-02-05",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 TL00BZ73-3001",
+                  "nimi": {
+                    "fi": "Kliininen ravitsemustiede"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kliininen ravitsemustiede"
+                },
+                "laajuus": {
+                  "arvo": 2.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-03-24",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-03-24",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4426203-1001",
+                  "nimi": {
+                    "fi": "Kirurgia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kirurgia"
+                },
+                "laajuus": {
+                  "arvo": 15.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-12-17",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-12-17",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424750-3011",
+                  "nimi": {
+                    "fi": "Silmätaudit"
+                  }
+                },
+                "nimi": {
+                  "fi": "Silmätaudit"
+                },
+                "laajuus": {
+                  "arvo": 6.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-05-12",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-05-12",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424350-1001",
+                  "nimi": {
+                    "fi": "Terveyskeskusopetus I"
+                  }
+                },
+                "nimi": {
+                  "fi": "Terveyskeskusopetus I"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-12-02",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-12-02",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 TL00CO60-3002",
+                  "nimi": {
+                    "fi": "Opinnäytetyöseminaari 1, LL"
+                  }
+                },
+                "nimi": {
+                  "fi": "Opinnäytetyöseminaari 1, LL"
+                },
+                "laajuus": {
+                  "arvo": 1.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-06-19",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-06-19",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "1008 Lääketieteen koulutusohjelma",
+                  "nimi": {
+                    "fi": "Pätevyys ll5"
+                  }
+                },
+                "nimi": {
+                  "fi": "Pätevyys ll5"
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-05-26",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-05-26",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 1131000",
+                  "nimi": {
+                    "fi": "Orientaatio yliopisto-opiskeluun"
+                  }
+                },
+                "nimi": {
+                  "fi": "Orientaatio yliopisto-opiskeluun"
+                },
+                "laajuus": {
+                  "arvo": 1.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2018-12-05",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2018-12-05",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422404",
+                  "nimi": {
+                    "fi": "Vuorovaikutus potilas-lääkärisuhteessa lääketieteen opiskelijoille"
+                  }
+                },
+                "nimi": {
+                  "fi": "Vuorovaikutus potilas-lääkärisuhteessa lääketieteen opiskelijoille"
+                },
+                "laajuus": {
+                  "arvo": 2.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-10-04",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-10-04",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 8012701A",
+                  "nimi": {
+                    "fi": "Ruotsin kirjallinen taito lääketieteen opiskelijoille"
+                  }
+                },
+                "nimi": {
+                  "fi": "Ruotsin kirjallinen taito lääketieteen opiskelijoille"
+                },
+                "laajuus": {
+                  "arvo": 1.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HT",
+                    "nimi": {
+                      "fi": "hyvät tiedot",
+                      "sv": "goda insikter",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HT"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-05-27",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-05-27",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4218802",
+                  "nimi": {
+                    "fi": "Systemaattinen farmakologia 1"
+                  }
+                },
+                "nimi": {
+                  "fi": "Systemaattinen farmakologia 1"
+                },
+                "laajuus": {
+                  "arvo": 4.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4",
+                      "sv": "4"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2020-04-20",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2020-04-20",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424200",
+                  "nimi": {
+                    "fi": "Kliininen Kemia"
+                  }
+                },
+                "nimi": {
+                  "fi": "Kliininen Kemia"
+                },
+                "laajuus": {
+                  "arvo": 3.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-04-16",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-04-16",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422410",
+                  "nimi": {
+                    "fi": "Epidemiologia ja biostatistiikka"
+                  }
+                },
+                "nimi": {
+                  "fi": "Epidemiologia ja biostatistiikka"
+                },
+                "laajuus": {
+                  "arvo": 4.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "lyhytNimi": {
+                      "fi": "2",
+                      "sv": "2"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-12-02",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-12-02",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4422608",
+                  "nimi": {
+                    "fi": "Hermosto"
+                  }
+                },
+                "nimi": {
+                  "fi": "Hermosto"
+                },
+                "laajuus": {
+                  "arvo": 8.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2019-12-09",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2019-12-09",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424150",
+                  "nimi": {
+                    "fi": "Keuhkosairaudet"
+                  }
+                },
+                "nimi": {
+                  "fi": "Keuhkosairaudet"
+                },
+                "laajuus": {
+                  "arvo": 4.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-04-28",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-04-28",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424000",
+                  "nimi": {
+                    "fi": "Anestesiologia ja tehohoito"
+                  }
+                },
+                "nimi": {
+                  "fi": "Anestesiologia ja tehohoito"
+                },
+                "laajuus": {
+                  "arvo": 4.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2021-03-05",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2021-03-05",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424400-1001",
+                  "nimi": {
+                    "fi": "Infektiosairaudet"
+                  }
+                },
+                "nimi": {
+                  "fi": "Infektiosairaudet"
+                },
+                "laajuus": {
+                  "arvo": 5.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "5",
+                      "sv": "5"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5",
+                      "sv": "5"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-03-18",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-03-18",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424252-3002",
+                  "nimi": {
+                    "fi": "Psykiatria ja nuorisopsykiatria"
+                  }
+                },
+                "nimi": {
+                  "fi": "Psykiatria ja nuorisopsykiatria"
+                },
+                "laajuus": {
+                  "arvo": 10.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "lyhytNimi": {
+                      "fi": "3",
+                      "sv": "3"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2022-05-09",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2022-05-09",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4425350-1002",
+                  "nimi": {
+                    "fi": "Terveyskeskusopetus III"
+                  }
+                },
+                "nimi": {
+                  "fi": "Terveyskeskusopetus III"
+                },
+                "laajuus": {
+                  "arvo": 1.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-05-26",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-05-26",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 4424550-3001",
+                  "nimi": {
+                    "fi": "Korva-, nenä- ja kurkkutaudit"
+                  }
+                },
+                "nimi": {
+                  "fi": "Korva-, nenä- ja kurkkutaudit"
+                },
+                "laajuus": {
+                  "arvo": 8.0,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-02-03",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-02-03",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LL18 TL00DA61-3001",
+                  "nimi": {
+                    "fi": "Oikeuspsykiatria"
+                  }
+                },
+                "nimi": {
+                  "fi": "Oikeuspsykiatria"
+                },
+                "laajuus": {
+                  "arvo": 1.5,
+                  "yksikkö": {
+                    "koodiarvo": "2",
+                    "nimi": {
+                      "fi": "opintopistettä",
+                      "sv": "studiepoäng",
+                      "en": "ECTS credits"
+                    },
+                    "lyhytNimi": {
+                      "fi": "op",
+                      "sv": "sp",
+                      "en": "ECTS cr"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "toimipiste": {
+                "oid": "1.2.246.562.10.38515028629",
+                "oppilaitosnumero": {
+                  "koodiarvo": "10088",
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "koodistoUri": "oppilaitosnumero",
+                  "koodistoVersio": 1
+                },
+                "nimi": {
+                  "fi": "Itä-Suomen yliopisto",
+                  "sv": "Östra Finlands Universitet",
+                  "en": "University of Eastern Finland"
+                },
+                "kotipaikka": {
+                  "koodiarvo": "167",
+                  "nimi": {
+                    "fi": "Joensuu",
+                    "sv": "Joensuu"
+                  },
+                  "koodistoUri": "kunta",
+                  "koodistoVersio": 2
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "HYV",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass/accepted"
+                    },
+                    "lyhytNimi": {
+                      "fi": "HYV"
+                    },
+                    "koodistoUri": "virtaarvosana",
+                    "koodistoVersio": 1
+                  },
+                  "päivä": "2023-09-01",
+                  "hyväksytty": true
+                }
+              ],
+              "vahvistus": {
+                "päivä": "2023-09-01",
+                "myöntäjäOrganisaatio": {
+                  "oid": "1.2.246.562.10.38515028629",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "10088",
+                    "nimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Itä-Suomen yliopisto",
+                      "sv": "Östra Finlands Universitet",
+                      "en": "University of Eastern Finland"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Itä-Suomen yliopisto",
+                    "sv": "Östra Finlands Universitet",
+                    "en": "University of Eastern Finland"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "167",
+                    "nimi": {
+                      "fi": "Joensuu",
+                      "sv": "Joensuu"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              },
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "korkeakoulunopintojakso",
+                "koodistoUri": "suorituksentyyppi"
+              }
+            }
+          ],
           "tyyppi": {
-            "koodiarvo": "aikuistenperusopetuksenoppimaaranalkuvaihe",
+            "koodiarvo": "korkeakoulututkinto",
+            "koodistoUri": "suorituksentyyppi"
+          }
+        }
+      ],
+      "tyyppi": {
+        "koodiarvo": "korkeakoulutus",
+        "nimi": {
+          "fi": "Korkeakoulutus",
+          "sv": "Högskoleutbildning",
+          "en": "Higher education"
+        },
+        "lyhytNimi": {
+          "fi": "Korkeakoulutus"
+        },
+        "koodistoUri": "opiskeluoikeudentyyppi",
+        "koodistoVersio": 1
+      },
+      "virtaVirheet": [],
+      "synteettinen": false,
+      "alkamispäivä": "2018-08-01"
+    },
+    {
+      "lähdejärjestelmänId": {
+        "lähdejärjestelmä": {
+          "koodiarvo": "ytr",
+          "nimi": {
+            "fi": "ytr"
+          },
+          "koodistoUri": "lahdejarjestelma",
+          "koodistoVersio": 1
+        }
+      },
+      "koulutustoimija": {
+        "oid": "1.2.246.562.10.43628088406",
+        "nimi": {
+          "fi": "Ylioppilastutkintolautakunta",
+          "sv": "Studentexamensnämnden",
+          "en": "The Matriculation Examination Board"
+        },
+        "kotipaikka": {
+          "koodiarvo": "091",
+          "nimi": {
+            "fi": "Helsinki",
+            "sv": "Helsingfors"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "tila": {
+        "opiskeluoikeusjaksot": []
+      },
+      "suoritukset": [
+        {
+          "koulutusmoduuli": {
+            "tunniste": {
+              "koodiarvo": "301000",
+              "nimi": {
+                "fi": "Ylioppilastutkinto",
+                "sv": "Studentexamen",
+                "en": "Matriculation Examination"
+              },
+              "lyhytNimi": {
+                "fi": "Ylioppilastutkinto",
+                "sv": "Studentexamen",
+                "en": "Matriculation Examination"
+              },
+              "koodistoUri": "koulutus",
+              "koodistoVersio": 12
+            }
+          },
+          "toimipiste": {
+            "oid": "1.2.246.562.10.43628088406",
             "nimi": {
-              "fi": "Aikuisten perusopetuksen oppimäärän alkuvaihe",
-              "sv": "Inledningsskedet i den grundläggande utbildningen för vuxna",
-              "en": "Introductory phase to basic education for adults  syllabus"
+              "fi": "Ylioppilastutkintolautakunta",
+              "sv": "Studentexamensnämnden",
+              "en": "The Matriculation Examination Board"
+            },
+            "kotipaikka": {
+              "koodiarvo": "091",
+              "nimi": {
+                "fi": "Helsinki",
+                "sv": "Helsingfors"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
+          },
+          "pakollisetKokeetSuoritettu": false,
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "FY",
+                  "nimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik",
+                    "en": "Physics"
+                  },
+                  "koodistoUri": "koskiyokokeet",
+                  "koodistoVersio": 1
+                }
+              },
+              "tutkintokerta": {
+                "koodiarvo": "2020K",
+                "vuosi": 2020,
+                "vuodenaika": {
+                  "fi": "kevät",
+                  "sv": "vår",
+                  "en": "spring"
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "B",
+                    "nimi": {
+                      "fi": "Lubenter approbatur"
+                    },
+                    "koodistoUri": "koskiyoarvosanat",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "ylioppilastutkinnonkoe",
+                "nimi": {
+                  "fi": "Ylioppilastutkinnon koe",
+                  "sv": "Prov i studentexamen",
+                  "en": "Matriculation examination test"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KE",
+                  "nimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi",
+                    "en": "Chemistry"
+                  },
+                  "koodistoUri": "koskiyokokeet",
+                  "koodistoVersio": 1
+                }
+              },
+              "tutkintokerta": {
+                "koodiarvo": "2020K",
+                "vuosi": 2020,
+                "vuodenaika": {
+                  "fi": "kevät",
+                  "sv": "vår",
+                  "en": "spring"
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "B",
+                    "nimi": {
+                      "fi": "Lubenter approbatur"
+                    },
+                    "koodistoUri": "koskiyoarvosanat",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "ylioppilastutkinnonkoe",
+                "nimi": {
+                  "fi": "Ylioppilastutkinnon koe",
+                  "sv": "Prov i studentexamen",
+                  "en": "Matriculation examination test"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            }
+          ],
+          "tyyppi": {
+            "koodiarvo": "ylioppilastutkinto",
+            "nimi": {
+              "fi": "Ylioppilastutkinto",
+              "sv": "Studentexamen",
+              "en": "Matriculation examination"
             },
             "koodistoUri": "suorituksentyyppi",
             "koodistoVersio": 1
@@ -163,23 +10130,22 @@
         }
       ],
       "tyyppi": {
-        "koodiarvo": "aikuistenperusopetus",
+        "koodiarvo": "ylioppilastutkinto",
         "nimi": {
-          "fi": "Aikuisten perusopetus",
-          "sv": "Grundläggande utbildning för vuxna",
-          "en": "Preparatory instruction and lower secondary education for adults"
+          "fi": "Ylioppilastutkinto",
+          "sv": "Studentexamen",
+          "en": "Matriculation Examination"
         },
         "lyhytNimi": {
-          "fi": "Aikuisten perusopetus"
+          "fi": "Ylioppilastutkinto"
         },
         "koodistoUri": "opiskeluoikeudentyyppi",
         "koodistoVersio": 1
-      },
-      "alkamispäivä": "2006-01-01"
+      }
     }
   ],
   "tokenInfo": {
     "scope": "HENKILOTIEDOT_HETU OPISKELUOIKEUDET_KAIKKI_TIEDOT",
-    "expirationTime": "2025-02-03T15:18:55.8604+02:00"
+    "expirationTime": "2025-03-20T16:23:18.488888+02:00"
   }
 }


### PR DESCRIPTION
## Description

- Integration with AI-based osaamiset tunnistus API for skill recognition.
- Provide new fields to client (front end): `osaamisetOdottaaTunnistusta` (tells if there is awaiting osaamiset identification), `osaamisetTunnistusEpaonnistui` (tells if osaamiset identification have failed) and `osasuoritukset`.
- Added new configurable key: jod.ai-tunnistus.osaamiset.endpoint

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1310