### PR TITLE
OPHJOD-1437: Set maxParallelForks dynamically for test execution  

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ compileJava {
 }
 
 test {
-  maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+  maxParallelForks = 3
 
   doFirst {
     println "Running tests with maxParallelForks = ${maxParallelForks}"

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,14 @@ compileJava {
   options.compilerArgs << '-Xlint:all,-processing,-serial'
 }
 
+test {
+  maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+
+  doFirst {
+    println "Running tests with maxParallelForks = ${maxParallelForks}"
+  }
+}
+
 repositories {
   mavenCentral()
   maven { url = "https://build.shibboleth.net/nexus/content/repositories/releases/" }

--- a/scripts/benchmark-test.sh
+++ b/scripts/benchmark-test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Script to measure Gradle test execution time
+echo "Starting Gradle test timer..."
+
+# Record the start time
+start_time=$(date +%s.%N)
+
+# Run gradle test
+echo "Running 'gradle test'..."
+# Save the current directory
+CURRENT_DIR=$(pwd)
+# Navigate to the parent directory
+cd "$(dirname "$0")/.." || { echo "Failed to change directory"; exit 1; }
+# Run gradle with proper error handling
+./gradlew cleanTest test || { echo "Gradle tests failed"; cd "$CURRENT_DIR" || true; exit 1; }
+# Return to the original directory
+cd "$CURRENT_DIR" || { echo "Failed to return to original directory"; exit 1; }
+
+# Record the end time
+end_time=$(date +%s.%N)
+
+# Calculate the runtime
+runtime=$(echo "$end_time - $start_time" | bc)
+
+# Format the runtime nicely with different units
+total_seconds=$(printf "%.2f" $runtime)
+minutes=$(echo "$runtime / 60" | bc)
+seconds=$(echo "$runtime % 60" | bc)
+
+# Print the results
+echo "----------------------------------------"
+echo "Gradle test execution completed!"
+echo "Total runtime: $total_seconds seconds = $minutes minutes and $seconds seconds"
+echo "----------------------------------------"


### PR DESCRIPTION
## Description  

Added support to configure `maxParallelForks` dynamically based on the number of available processors. Defaults to 1 if processor information is not accessible. This enhances test execution efficiency by improving parallelism and includes a log statement for visibility.  

## Related JIRA ticket  

https://jira.eduuni.fi/browse/OPHJOD-1437  