### PR TITLE
OPHJOD-1410: Change Mahdollisuudet import with upsert logic

### DIFF
--- a/scripts/update-local-env-data.sh
+++ b/scripts/update-local-env-data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
-echo "NOTE: This script will DELETE all user data related to tyomahdollisuus and koulutusmahdollisuus from:
+echo "NOTE: This script will UPDATE all user data related to tyomahdollisuus and koulutusmahdollisuus from:
  - tyomahdollisuus_jakauma_arvot
  - paamaara
  - tyomahdollisuus_kaannos
@@ -47,7 +47,7 @@ fi
 echo "CLEAR and UPDATE tyomahdollisuus, koulutusmahdollisuus and esco"
 (
   docker exec -i -e PGPASSWORD=yksilo "$DB" psql -q -1 -U yksilo yksilo \
-    -c "CALL tyomahdollisuus_data.clear(); CALL koulutusmahdollisuus_data.clear(); CALL tyomahdollisuus_data.import(); CALL koulutusmahdollisuus_data.import();"
+    -c "CALL tyomahdollisuus_data.import(); CALL koulutusmahdollisuus_data.import();"
 
   #update esco data
   for esco in "ammatti" "osaaminen"; do

--- a/src/main/java/fi/okm/jod/yksilo/dto/KoulutusmahdollisuusDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/KoulutusmahdollisuusDto.java
@@ -20,4 +20,5 @@ public record KoulutusmahdollisuusDto(
     @NotNull LocalizedString otsikko,
     LocalizedString tiivistelma,
     LocalizedString kuvaus,
-    KestoJakaumaDto kesto) {}
+    KestoJakaumaDto kesto,
+    Boolean aktiivinen) {}

--- a/src/main/java/fi/okm/jod/yksilo/dto/TyomahdollisuusDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/TyomahdollisuusDto.java
@@ -17,4 +17,5 @@ public record TyomahdollisuusDto(
     @NotNull UUID id,
     @NotNull LocalizedString otsikko,
     LocalizedString tiivistelma,
-    LocalizedString kuvaus) {}
+    LocalizedString kuvaus,
+    Boolean aktiivinen) {}

--- a/src/main/java/fi/okm/jod/yksilo/entity/koulutusmahdollisuus/Koulutusmahdollisuus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/koulutusmahdollisuus/Koulutusmahdollisuus.java
@@ -58,6 +58,9 @@ public class Koulutusmahdollisuus {
   @MapKeyColumn(name = "tyyppi")
   private Map<KoulutusmahdollisuusJakaumaTyyppi, KoulutusmahdollisuusJakauma> jakaumat;
 
+  @Column(columnDefinition = "boolean default true")
+  private boolean aktiivinen = true;
+
   @Embedded
   @AttributeOverride(name = "minimi", column = @Column(name = "kesto_minimi"))
   @AttributeOverride(name = "mediaani", column = @Column(name = "kesto_mediaani"))

--- a/src/main/java/fi/okm/jod/yksilo/entity/koulutusmahdollisuus/KoulutusmahdollisuusJakauma.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/koulutusmahdollisuus/KoulutusmahdollisuusJakauma.java
@@ -23,6 +23,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.List;
 import lombok.Getter;
 import org.hibernate.annotations.BatchSize;
@@ -48,6 +49,11 @@ public class KoulutusmahdollisuusJakauma implements Jakauma<Koulutusmahdollisuus
 
   @ElementCollection
   @BatchSize(size = 100)
-  @CollectionTable(indexes = {@Index(columnList = "koulutusmahdollisuus_jakauma_id")})
+  @CollectionTable(
+      uniqueConstraints = {
+        @UniqueConstraint(
+            name = "koulutusmahdollisuus_jakauma_id_arvo",
+            columnNames = {"koulutusmahdollisuus_jakauma_id", "arvo"})
+      })
   private List<Jakauma.Arvo> arvot;
 }

--- a/src/main/java/fi/okm/jod/yksilo/entity/tyomahdollisuus/Tyomahdollisuus.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/tyomahdollisuus/Tyomahdollisuus.java
@@ -54,6 +54,9 @@ public class Tyomahdollisuus {
   @Column
   private TyomahdollisuusAineisto aineisto;
 
+  @Column(columnDefinition = "boolean default true")
+  private boolean aktiivinen = true;
+
   @Embeddable
   public record Kaannos(
       @Column(length = Integer.MAX_VALUE) String otsikko,

--- a/src/main/java/fi/okm/jod/yksilo/entity/tyomahdollisuus/TyomahdollisuusJakauma.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/tyomahdollisuus/TyomahdollisuusJakauma.java
@@ -23,6 +23,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.List;
 import lombok.Getter;
 import org.hibernate.annotations.BatchSize;
@@ -48,6 +49,11 @@ public class TyomahdollisuusJakauma implements Jakauma<TyomahdollisuusJakaumaTyy
 
   @ElementCollection
   @BatchSize(size = 100)
-  @CollectionTable(indexes = {@Index(columnList = "tyomahdollisuus_jakauma_id")})
-  private List<Arvo> arvot;
+  @CollectionTable(
+      uniqueConstraints = {
+        @UniqueConstraint(
+            name = "tyomahdollisuus_jakauma_id_arvo",
+            columnNames = {"tyomahdollisuus_jakauma_id", "arvo"})
+      })
+  private List<Jakauma.Arvo> arvot;
 }

--- a/src/main/java/fi/okm/jod/yksilo/service/KoulutusmahdollisuusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/KoulutusmahdollisuusService.java
@@ -47,7 +47,8 @@ public class KoulutusmahdollisuusService {
             entity.getOtsikko(),
             entity.getTiivistelma(),
             entity.getKuvaus(),
-            mapKesto(entity.getKesto()));
+            mapKesto(entity.getKesto()),
+            entity.isAktiivinen());
   }
 
   private static KoulutusmahdollisuusFullDto mapFull(Koulutusmahdollisuus entity) {

--- a/src/main/java/fi/okm/jod/yksilo/service/TyomahdollisuusService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/TyomahdollisuusService.java
@@ -60,7 +60,11 @@ public class TyomahdollisuusService {
     return entity == null
         ? null
         : new TyomahdollisuusDto(
-            entity.getId(), entity.getOtsikko(), entity.getTiivistelma(), entity.getKuvaus());
+            entity.getId(),
+            entity.getOtsikko(),
+            entity.getTiivistelma(),
+            entity.getKuvaus(),
+            entity.isAktiivinen());
   }
 
   private static TyomahdollisuusFullDto mapFull(Tyomahdollisuus entity) {

--- a/src/main/java/fi/okm/jod/yksilo/service/ehdotus/MahdollisuudetService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/ehdotus/MahdollisuudetService.java
@@ -35,12 +35,13 @@ public class MahdollisuudetService {
 
   private static final String SQL_UNION_OF_TYO_AND_KOULUTUSMAHDOLLISUUS_IDS =
       """
-      SELECT * FROM (SELECT tyomahdollisuus_id AS id, otsikko, ''TYOMAHDOLLISUUS'' AS tyyppi
-      FROM tyomahdollisuus_kaannos tk
+      SELECT * FROM (SELECT tk.tyomahdollisuus_id AS id, tk.otsikko, ''TYOMAHDOLLISUUS'' AS tyyppi
+      FROM tyomahdollisuus_kaannos tk LEFT JOIN tyomahdollisuus t ON tk.tyomahdollisuus_id = t.id
+      WHERE tk.kaannos_key = :lang AND t.aktiivinen IS true
       UNION
-      SELECT koulutusmahdollisuus_id AS id, otsikko, ''KOULUTUSMAHDOLLISUUS'' AS tyyppi
-      FROM koulutusmahdollisuus_kaannos kk
-      WHERE kaannos_key = :lang) ORDER BY otsikko COLLATE  "{0}" {1}
+      SELECT kk.koulutusmahdollisuus_id AS id, kk.otsikko, ''KOULUTUSMAHDOLLISUUS'' AS tyyppi
+      FROM koulutusmahdollisuus_kaannos kk LEFT JOIN koulutusmahdollisuus k ON kk.koulutusmahdollisuus_id = k.id
+      WHERE kk.kaannos_key = :lang AND k.aktiivinen IS true ) ORDER BY otsikko COLLATE  "{0}" {1}
       """;
 
   private final EntityManager entityManager;

--- a/src/test/java/fi/okm/jod/yksilo/controller/TyomahdollisuusControllerTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/controller/TyomahdollisuusControllerTest.java
@@ -79,7 +79,8 @@ class TyomahdollisuusControllerTest {
                 mockIds.stream().findFirst().orElse(UUID.randomUUID()),
                 otsikko,
                 tiivistelma,
-                kuvaus));
+                kuvaus,
+                true));
     when(service.findByIds(mockIds)).thenReturn(mockTyomahdolliuudet);
 
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/src/test/java/fi/okm/jod/yksilo/service/MahdollisuusImportTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/MahdollisuusImportTest.java
@@ -9,13 +9,27 @@
 
 package fi.okm.jod.yksilo.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import fi.okm.jod.yksilo.domain.Kieli;
+import fi.okm.jod.yksilo.domain.KoulutusmahdollisuusJakaumaTyyppi;
 import fi.okm.jod.yksilo.domain.KoulutusmahdollisuusTyyppi;
 import fi.okm.jod.yksilo.domain.TyomahdollisuusAineisto;
+import fi.okm.jod.yksilo.domain.TyomahdollisuusJakaumaTyyppi;
+import fi.okm.jod.yksilo.entity.Jakauma;
+import fi.okm.jod.yksilo.entity.koulutusmahdollisuus.Koulutusmahdollisuus;
+import fi.okm.jod.yksilo.entity.koulutusmahdollisuus.KoulutusmahdollisuusJakauma;
+import fi.okm.jod.yksilo.entity.tyomahdollisuus.Tyomahdollisuus;
+import fi.okm.jod.yksilo.entity.tyomahdollisuus.TyomahdollisuusJakauma;
 import fi.okm.jod.yksilo.testutil.TestUtil;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -37,53 +51,346 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DataJpaTest(showSql = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
-@SqlConfig(separator = ";;;")
-@Sql(scripts = {"/data/mock-tunnistus.sql", "/schema.sql", "/data.sql", "/data/mahdollisuudet.sql"})
+@Sql(
+    scripts = {"/data/mock-tunnistus.sql", "/schema.sql", "/data.sql"},
+    config = @SqlConfig(separator = ";;;"),
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+@Sql(
+    scripts = {"/data/mahdollisuudet.sql"},
+    config = @SqlConfig(separator = ";;;"),
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @DirtiesContext
 @Import({TyomahdollisuusService.class, KoulutusmahdollisuusService.class})
 @Execution(ExecutionMode.CONCURRENT)
 @ResourceLock("SLOW")
-public class MahdollisuusImportTest {
+class MahdollisuusImportTest {
 
   @Container @ServiceConnection
   static PostgreSQLContainer<?> postgreSQLContainer = TestUtil.createPostgresSQLContainer();
 
-  @Autowired protected TestEntityManager entityManager;
+  private static final String KOULUTUSMAHDOLLISUUS_IMPORT_DATA_PROCEDURE =
+      "koulutusmahdollisuus_data.import";
+  private static final String KOULUTUSMAHDOLLISUUS_UPDATE_WITH_EXTENDED_IMPORT_DATA_SQL =
+      "/data/mahdollisuudet-koulutus-update-import-data-extended.sql";
+  private static final String KOULUTUSMAHDOLLISUUS_UPDATE_WITH_REDUCED_IMPORT_DATA_SQL =
+      "/data/mahdollisuudet-koulutus-update-import-data-reduced.sql";
+  private static final String KOULUTUSMAHDOLLISUUS_DELETE_IMPORT_DATA_SQL =
+      "/data/mahdollisuudet-koulutus-delete-import-data.sql";
 
-  @Autowired private TyomahdollisuusService tyomahdollisuusService;
-  @Autowired private KoulutusmahdollisuusService koulutusmahdollisuusService;
+  private static final UUID KOULUTUSMAHDOLLISUUS_ID =
+      UUID.fromString("30080e88-f292-48a3-9835-41950817abd3");
+  private static final String KOULUTUSMAHDOLLISUUS_JAKAUMA_OSAAMINEN_KEY =
+      "http://data.europa.eu/esco/skill/bfe4f330-d595-48c7-ab3c-f309471d6953";
+
+  private static final String TYOMAHDOLLISUUS_IMPORT_DATA_PROCEDURE = "tyomahdollisuus_data.import";
+  private static final String TYOMAHDOLLISUUS_UPDATE_WITH_EXTENDED_IMPORT_DATA_SQL =
+      "/data/mahdollisuudet-tyo-update-import-data-extended.sql";
+  private static final String TYOMAHDOLLISUUS_UPDATE_WITH_REDUCED_IMPORT_DATA_SQL =
+      "/data/mahdollisuudet-tyo-update-import-data-reduced.sql";
+  private static final String TYOMAHDOLLISUUS_DELETE_IMPORT_DATA_SQL =
+      "/data/mahdollisuudet-tyo-delete-import-data.sql";
+
+  private static final UUID TYOMAHDOLLISUUS_ID =
+      UUID.fromString("bc77f514-8573-11ef-8f0c-b767f527df04");
+  private static final String TYOMAHDOLLISUUS_JAKAUMA_TYON_JATKUVUUS_KEY = "PERMANENT";
+
+  @Autowired private TestEntityManager entityManager;
 
   @Test
-  void shouldImportMahdollisuusData() {
-    assertDoesNotThrow(
-        () -> {
-          entityManager
-              .getEntityManager()
-              .createStoredProcedureQuery("tyomahdollisuus_data.import")
-              .execute();
-        });
-    assertDoesNotThrow(
-        () -> {
-          entityManager
-              .getEntityManager()
-              .createStoredProcedureQuery("koulutusmahdollisuus_data.import")
-              .execute();
-        });
+  void shouldImportKoulutusMahdollisuusData_extendedDataset() throws IOException {
+    // Initial state check
+    var entity = entityManager.find(Koulutusmahdollisuus.class, KOULUTUSMAHDOLLISUUS_ID);
+    assertNull(entity, "Koulutusmahdollisuus should not exist initially");
 
-    var k =
-        assertDoesNotThrow(
-            () ->
-                koulutusmahdollisuusService.get(
-                    UUID.fromString("30080e88-f292-48a3-9835-41950817abd3")));
-    assertEquals(KoulutusmahdollisuusTyyppi.TUTKINTO, k.tyyppi());
-    assertThat(k.jakaumat()).isNotEmpty();
+    // First import
+    runSqlProcedure(KOULUTUSMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Koulutusmahdollisuus.class, KOULUTUSMAHDOLLISUUS_ID);
+    assertKoulutusMahdollisuusFirstImport(entity);
 
-    var t =
-        assertDoesNotThrow(
-            () ->
-                tyomahdollisuusService.get(
-                    UUID.fromString("bc77f514-8573-11ef-8f0c-b767f527df04")));
-    assertEquals(TyomahdollisuusAineisto.TMT, t.aineisto());
-    assertThat(t.jakaumat()).isNotEmpty();
+    // Apply update script and re-import that does upsert
+    runSqlScript(KOULUTUSMAHDOLLISUUS_UPDATE_WITH_EXTENDED_IMPORT_DATA_SQL);
+    runSqlProcedure(KOULUTUSMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Koulutusmahdollisuus.class, KOULUTUSMAHDOLLISUUS_ID);
+    assertNotNull(entity, "Koulutusmahdollisuus should exist after update");
+    assertTrue(entity.isAktiivinen());
+    assertEquals(KoulutusmahdollisuusTyyppi.TUTKINTO, entity.getTyyppi());
+    // Check updated data
+    var kaannos = entity.getKaannos();
+    assertEquals(3, kaannos.size());
+    assertOtsikko(
+        kaannos,
+        "Uusi Psykologian yliopistotutkinto",
+        "Nya Kandidatexamen i psykologi",
+        "New Degree in psychology");
+    assertEquals(3, entity.getKoulutukset().size(), "1 more koulutus was added.");
+    assertKesto(entity.getKesto(), 6, 51, 121);
+    var jakaumat = entity.getJakaumat();
+    assertEquals(6, jakaumat.size());
+    assertJakauma(
+        jakaumat.get(KoulutusmahdollisuusJakaumaTyyppi.OSAAMINEN),
+        90,
+        4,
+        KOULUTUSMAHDOLLISUUS_JAKAUMA_OSAAMINEN_KEY,
+        60);
+    var newKey = "http://data.europa.eu/esco/skill/00920055-eb50-4cb8-a23d-3deedbf3753e";
+    assertJakauma(jakaumat.get(KoulutusmahdollisuusJakaumaTyyppi.OSAAMINEN), 90, 4, newKey, 1);
+
+    // Delete source of import data and re-import
+    runSqlScript(KOULUTUSMAHDOLLISUUS_DELETE_IMPORT_DATA_SQL);
+    runSqlProcedure(KOULUTUSMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Koulutusmahdollisuus.class, KOULUTUSMAHDOLLISUUS_ID);
+    assertFalse(entity.isAktiivinen());
+  }
+
+  private static void assertKoulutusMahdollisuusFirstImport(Koulutusmahdollisuus entity) {
+    assertNotNull(entity, "Koulutusmahdollisuus should exist after import");
+    assertTrue(entity.isAktiivinen());
+    assertEquals(KoulutusmahdollisuusTyyppi.TUTKINTO, entity.getTyyppi());
+    var kaannos = entity.getKaannos();
+    assertOtsikko(
+        kaannos,
+        "Psykologian yliopistotutkinto",
+        "Kandidatexamen i psykologi",
+        "Degree in psychology");
+    assertEquals(2, entity.getKoulutukset().size());
+    var koulutukset = entity.getKoulutukset();
+    var koulutusViite = koulutukset.iterator().next();
+    assertEquals(3, koulutusViite.getKaannos().size());
+
+    assertKesto(entity.getKesto(), 5, 50, 120);
+    var jakaumat = entity.getJakaumat();
+    assertEquals(6, jakaumat.size());
+    assertJakauma(
+        jakaumat.get(KoulutusmahdollisuusJakaumaTyyppi.OSAAMINEN),
+        100,
+        5,
+        KOULUTUSMAHDOLLISUUS_JAKAUMA_OSAAMINEN_KEY,
+        50);
+  }
+
+  private static void assertKesto(
+      Koulutusmahdollisuus.KestoJakauma kesto, double minimi, double mediaani, double maksimi) {
+    assertEquals(minimi, kesto.minimi());
+    assertEquals(mediaani, kesto.mediaani());
+    assertEquals(maksimi, kesto.maksimi());
+  }
+
+  private static Optional<Jakauma.Arvo> assertJakauma(
+      KoulutusmahdollisuusJakauma jakauma, int maara, int tyhjia, String arvo, double osuus) {
+    assertEquals(maara, jakauma.getMaara());
+    assertEquals(tyhjia, jakauma.getTyhjia());
+    var foundArvo = jakauma.getArvot().stream().filter(a -> arvo.equals(a.arvo())).findFirst();
+    if (foundArvo.isPresent()) {
+      var arvo1 = foundArvo.get();
+      assertEquals(osuus, arvo1.osuus());
+    }
+    return foundArvo;
+  }
+
+  private static void assertOtsikko(
+      Map<Kieli, Koulutusmahdollisuus.Kaannos> kaannos,
+      String expectedFi,
+      String expectedSv,
+      String expectedEn) {
+    assertEquals(expectedFi, kaannos.get(Kieli.FI).otsikko());
+    assertEquals(expectedSv, kaannos.get(Kieli.SV).otsikko());
+    assertEquals(expectedEn, kaannos.get(Kieli.EN).otsikko());
+  }
+
+  private void runSqlProcedure(String procedureName) {
+    entityManager.getEntityManager().createStoredProcedureQuery(procedureName).execute();
+    entityManager.flush();
+    entityManager.clear();
+  }
+
+  private void runSqlScript(String scriptPath) throws IOException {
+    String sqlScript;
+    try (var resourceAsStream = getClass().getResourceAsStream(scriptPath)) {
+      assert resourceAsStream != null;
+      var bytes = resourceAsStream.readAllBytes();
+      sqlScript = new String(bytes);
+    }
+    entityManager.getEntityManager().createNativeQuery(sqlScript).executeUpdate();
+    entityManager.flush();
+    entityManager.clear();
+  }
+
+  @Test
+  void shouldImportKoulutusMahdollisuusData_reducedDataset() throws IOException {
+    // Initial state check
+    var entity = entityManager.find(Koulutusmahdollisuus.class, KOULUTUSMAHDOLLISUUS_ID);
+    assertNull(entity, "Koulutusmahdollisuus should not exist initially");
+
+    // First import
+    runSqlProcedure(KOULUTUSMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Koulutusmahdollisuus.class, KOULUTUSMAHDOLLISUUS_ID);
+    assertKoulutusMahdollisuusFirstImport(entity);
+    assertNotNull(entity.getJakaumat().get(KoulutusmahdollisuusJakaumaTyyppi.KOULUTUSALA));
+
+    // Apply update script and re-import that does upsert
+    runSqlScript(KOULUTUSMAHDOLLISUUS_UPDATE_WITH_REDUCED_IMPORT_DATA_SQL);
+    runSqlProcedure(KOULUTUSMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Koulutusmahdollisuus.class, KOULUTUSMAHDOLLISUUS_ID);
+    assertNotNull(entity, "Koulutusmahdollisuus should exist after update");
+    assertTrue(entity.isAktiivinen());
+    assertEquals(KoulutusmahdollisuusTyyppi.TUTKINTO, entity.getTyyppi());
+    // Check updated data
+    var kaannos = entity.getKaannos();
+    assertEquals(3, kaannos.size());
+    assertOtsikko(
+        kaannos,
+        "Uusi Psykologian yliopistotutkinto",
+        "Nya Kandidatexamen i psykologi",
+        "New Degree in psychology");
+    assertEquals(
+        1, entity.getKoulutukset().size(), "1 koulutus was removed, so it should be less now.");
+    var koulutukset = entity.getKoulutukset();
+    var koulutusViite = koulutukset.iterator().next();
+    assertEquals(2, koulutusViite.getKaannos().size(), "SV was removed, so it should be less now.");
+    assertKesto(entity.getKesto(), 6, 51, 121);
+    var jakaumat = entity.getJakaumat();
+    assertEquals(
+        5, jakaumat.size(), "1 koulutusalaJakauma was removed, so it should be 1 less now.");
+    assertNull(jakaumat.get(KoulutusmahdollisuusJakaumaTyyppi.KOULUTUSALA));
+    assertFalse(
+        assertJakauma(
+                jakaumat.get(KoulutusmahdollisuusJakaumaTyyppi.OSAAMINEN),
+                90,
+                4,
+                KOULUTUSMAHDOLLISUUS_JAKAUMA_OSAAMINEN_KEY,
+                0)
+            .isPresent(),
+        "Key was removed, so it shouldn't be present");
+
+    // Delete source of import data and re-import
+    runSqlScript(KOULUTUSMAHDOLLISUUS_DELETE_IMPORT_DATA_SQL);
+    runSqlProcedure(KOULUTUSMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Koulutusmahdollisuus.class, KOULUTUSMAHDOLLISUUS_ID);
+    assertFalse(entity.isAktiivinen());
+  }
+
+  @Test
+  void shouldImportTyoMahdollisuusData_extendedDataset() throws IOException {
+    // Initial state check
+    var entity = entityManager.find(Tyomahdollisuus.class, TYOMAHDOLLISUUS_ID);
+    assertNull(entity, "Tyomahdollisuus should not exist initially");
+
+    // First import
+    runSqlProcedure(TYOMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Tyomahdollisuus.class, TYOMAHDOLLISUUS_ID);
+    assertTyomahdollisuusFirstImport(entity);
+
+    // Apply update script and re-import that does upsert
+    runSqlScript(TYOMAHDOLLISUUS_UPDATE_WITH_EXTENDED_IMPORT_DATA_SQL);
+    runSqlProcedure(TYOMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Tyomahdollisuus.class, TYOMAHDOLLISUUS_ID);
+    assertNotNull(entity, "Should exist after import.");
+    assertEquals(TyomahdollisuusAineisto.AMMATTITIETO, entity.getAineisto());
+    assertTrue(entity.isAktiivinen());
+    // Check updated data
+    assertEquals(URI.create("http://data.europa.eu/esco/isco/C2149"), entity.getAmmattiryhma());
+    var kaannos = entity.getKaannos();
+    assertEquals(3, kaannos.size());
+    assertTyoOtsikko(kaannos, "Uusi Kouluttaja", "Nya Kouluttaja", "New Kouluttaja");
+    var jakaumat = entity.getJakaumat();
+    assertEquals(17, jakaumat.size());
+    assertJakauma(
+        jakaumat.get(TyomahdollisuusJakaumaTyyppi.TYON_JATKUVUUS),
+        30,
+        1,
+        TYOMAHDOLLISUUS_JAKAUMA_TYON_JATKUVUUS_KEY,
+        80.5);
+
+    // Delete source of import data and re-import
+    runSqlScript(TYOMAHDOLLISUUS_DELETE_IMPORT_DATA_SQL);
+    runSqlProcedure(TYOMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Tyomahdollisuus.class, TYOMAHDOLLISUUS_ID);
+    assertFalse(entity.isAktiivinen());
+  }
+
+  private static void assertTyomahdollisuusFirstImport(Tyomahdollisuus entity) {
+    assertNotNull(entity, "Tyomahdollisuus should exist after import");
+    assertEquals(TyomahdollisuusAineisto.TMT, entity.getAineisto());
+    assertTrue(entity.isAktiivinen());
+    assertEquals(URI.create(""), entity.getAmmattiryhma());
+    var kaannos = entity.getKaannos();
+    assertEquals(3, kaannos.size());
+    assertTyoOtsikko(kaannos, "Kouluttaja", "Kouluttaja", "Kouluttaja");
+    var jakaumat = entity.getJakaumat();
+    assertEquals(17, jakaumat.size());
+    assertJakauma(
+        jakaumat.get(TyomahdollisuusJakaumaTyyppi.TYON_JATKUVUUS),
+        24,
+        0,
+        TYOMAHDOLLISUUS_JAKAUMA_TYON_JATKUVUUS_KEY,
+        66.66666666666666);
+  }
+
+  private static void assertTyoOtsikko(
+      Map<Kieli, Tyomahdollisuus.Kaannos> kaannos,
+      String expectedFi,
+      String expectedSv,
+      String expectedEn) {
+    assertEquals(expectedFi, kaannos.get(Kieli.FI).otsikko());
+    var sv = kaannos.get(Kieli.SV);
+    if (expectedSv != null) {
+      assertEquals(expectedSv, sv.otsikko());
+    } else {
+      assertNull(sv);
+    }
+    assertEquals(expectedEn, kaannos.get(Kieli.EN).otsikko());
+  }
+
+  private static Optional<Jakauma.Arvo> assertJakauma(
+      TyomahdollisuusJakauma jakauma, int maara, int tyhjia, String arvo, double osuus) {
+    assertEquals(maara, jakauma.getMaara());
+    assertEquals(tyhjia, jakauma.getTyhjia());
+    var foundArvo = jakauma.getArvot().stream().filter(a -> arvo.equals(a.arvo())).findFirst();
+    if (foundArvo.isPresent()) {
+      var arvo1 = foundArvo.get();
+      assertEquals(osuus, arvo1.osuus());
+    }
+    return foundArvo;
+  }
+
+  @Test
+  void shouldImportTyoMahdollisuusData_reducedDataset() throws IOException {
+    // Initial state check
+    var entity = entityManager.find(Tyomahdollisuus.class, TYOMAHDOLLISUUS_ID);
+    assertNull(entity, "Tyomahdollisuus should not exist initially");
+
+    // First import
+    runSqlProcedure(TYOMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Tyomahdollisuus.class, TYOMAHDOLLISUUS_ID);
+    assertTyomahdollisuusFirstImport(entity);
+
+    // Apply update script and re-import that does upsert
+    runSqlScript(TYOMAHDOLLISUUS_UPDATE_WITH_REDUCED_IMPORT_DATA_SQL);
+    runSqlProcedure(TYOMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Tyomahdollisuus.class, TYOMAHDOLLISUUS_ID);
+    assertNotNull(entity, "Should exist after import.");
+    assertEquals(TyomahdollisuusAineisto.AMMATTITIETO, entity.getAineisto());
+    assertTrue(entity.isAktiivinen());
+    // Check updated data
+    assertEquals(URI.create("http://data.europa.eu/esco/isco/C2149"), entity.getAmmattiryhma());
+    var kaannos = entity.getKaannos();
+    assertEquals(2, kaannos.size());
+    assertTyoOtsikko(kaannos, "Uusi Kouluttaja", null, "New Kouluttaja");
+    var jakaumat = entity.getJakaumat();
+    assertEquals(16, jakaumat.size(), "ajokorttiJakauma was removed, so it should be 1 less now.");
+    assertFalse(
+        assertJakauma(
+                jakaumat.get(TyomahdollisuusJakaumaTyyppi.TYON_JATKUVUUS),
+                30,
+                1,
+                TYOMAHDOLLISUUS_JAKAUMA_TYON_JATKUVUUS_KEY,
+                0)
+            .isPresent());
+
+    // Delete source of import data and re-import
+    runSqlScript(TYOMAHDOLLISUUS_DELETE_IMPORT_DATA_SQL);
+    runSqlProcedure(TYOMAHDOLLISUUS_IMPORT_DATA_PROCEDURE);
+    entity = entityManager.find(Tyomahdollisuus.class, TYOMAHDOLLISUUS_ID);
+    assertFalse(entity.isAktiivinen());
   }
 }

--- a/src/test/java/fi/okm/jod/yksilo/service/ehdotus/MahdollisuudetServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/ehdotus/MahdollisuudetServiceTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.service.ehdotus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fi.okm.jod.yksilo.domain.Kieli;
+import fi.okm.jod.yksilo.domain.KoulutusmahdollisuusTyyppi;
+import fi.okm.jod.yksilo.domain.MahdollisuusTyyppi;
+import fi.okm.jod.yksilo.domain.TyomahdollisuusAineisto;
+import fi.okm.jod.yksilo.service.AbstractServiceTest;
+import jakarta.persistence.EntityManager;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Sort;
+
+@Import(MahdollisuudetService.class)
+class MahdollisuudetServiceTest extends AbstractServiceTest {
+
+  private static final UUID koulutusIdActive =
+      UUID.fromString("481e204a-691a-48dd-9b01-7f08d5858db9");
+  private static final UUID koulutusIdInactive =
+      UUID.fromString("c74eed41-c729-433e-8d36-4fc7527fe3df");
+  private static final UUID tyoIdActive = UUID.fromString("ca466237-ce1d-4aca-9f9b-2ed566ef4f94");
+  private static final UUID tyoIdInactive = UUID.fromString("af34f11f-05b5-434c-963a-df6d89a2149b");
+
+  @Autowired private MahdollisuudetService mahdollisuudetService;
+
+  @BeforeEach
+  void setUp() {
+    var em = entityManager.getEntityManager();
+
+    em.createQuery("DELETE FROM Koulutusmahdollisuus").executeUpdate();
+    em.createQuery("DELETE FROM Tyomahdollisuus").executeUpdate();
+
+    createKoulutusMahdollisuus(em, koulutusIdActive, true, KoulutusmahdollisuusTyyppi.TUTKINTO);
+    createKoulutusMahdollisuusKaannos(
+        em, koulutusIdActive, Kieli.FI, "Koulutusmahdollisuus", "Kuvaus", "Tiivistelmä");
+    createKoulutusMahdollisuusKaannos(
+        em, koulutusIdActive, Kieli.EN, "Educational opportunity", "Description", "Summary");
+
+    createKoulutusMahdollisuus(
+        em, koulutusIdInactive, false, KoulutusmahdollisuusTyyppi.EI_TUTKINTO);
+    createKoulutusMahdollisuusKaannos(
+        em, koulutusIdInactive, Kieli.FI, "Koulutusmahdollisuus", "Kuvaus", "Tiivistelmä");
+    createKoulutusMahdollisuusKaannos(
+        em, koulutusIdInactive, Kieli.EN, "Educational opportunity", "Description", "Summary");
+
+    createTyoMahdollisuus(em, tyoIdActive, true, TyomahdollisuusAineisto.TMT);
+    createTyoMahdollisuusKaannos(
+        em,
+        tyoIdActive,
+        Kieli.FI,
+        "Työmahdollisuus",
+        "Kuvaus",
+        "Tiivistelmä",
+        "Tehtävät",
+        "Vaatimukset");
+    createTyoMahdollisuusKaannos(
+        em,
+        tyoIdActive,
+        Kieli.EN,
+        "Job opportunity",
+        "Description",
+        "Summary",
+        "Tasks",
+        "Requirements");
+    createTyoMahdollisuus(em, tyoIdInactive, false, TyomahdollisuusAineisto.AMMATTITIETO);
+    createTyoMahdollisuusKaannos(
+        em,
+        tyoIdInactive,
+        Kieli.FI,
+        "Työmahdollisuus",
+        "Kuvaus",
+        "Tiivistelmä",
+        "Tehtävät",
+        "Vaatimukset");
+    createTyoMahdollisuusKaannos(
+        em,
+        tyoIdInactive,
+        Kieli.EN,
+        "Job opportunity",
+        "Description",
+        "Summary",
+        "Tasks",
+        "Requirements");
+
+    entityManager.flush();
+  }
+
+  private static void createKoulutusMahdollisuus(
+      EntityManager em, UUID id, boolean active, KoulutusmahdollisuusTyyppi tyyppi) {
+    em.createNativeQuery(
+            "INSERT INTO koulutusmahdollisuus (id, aktiivinen, tyyppi) VALUES (?1, ?2, ?3)")
+        .setParameter(1, id)
+        .setParameter(2, active)
+        .setParameter(3, tyyppi.name())
+        .executeUpdate();
+  }
+
+  private static void createKoulutusMahdollisuusKaannos(
+      EntityManager em,
+      UUID id,
+      Kieli language,
+      String header,
+      String description,
+      String summary) {
+    em.createNativeQuery(
+            "INSERT INTO koulutusmahdollisuus_kaannos (koulutusmahdollisuus_id, kaannos_key, otsikko, kuvaus, tiivistelma) VALUES (?1, ?2, ?3, ?4, ?5)")
+        .setParameter(1, id)
+        .setParameter(2, language.name())
+        .setParameter(3, header)
+        .setParameter(4, description)
+        .setParameter(5, summary)
+        .executeUpdate();
+  }
+
+  private static void createTyoMahdollisuus(
+      EntityManager em, UUID id, boolean active, TyomahdollisuusAineisto source) {
+    em.createNativeQuery(
+            "INSERT INTO tyomahdollisuus (id, aktiivinen, aineisto) VALUES (?1, ?2, ?3)")
+        .setParameter(1, id)
+        .setParameter(2, active)
+        .setParameter(3, source.name())
+        .executeUpdate();
+  }
+
+  private static void createTyoMahdollisuusKaannos(
+      EntityManager em,
+      UUID id,
+      Kieli kieli,
+      String jobOpportunity,
+      String description,
+      String summary,
+      String tasks,
+      String requirements) {
+    em.createNativeQuery(
+            "INSERT INTO tyomahdollisuus_kaannos (tyomahdollisuus_id, kaannos_key, otsikko, kuvaus, tiivistelma, tehtavat, yleiset_vaatimukset) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+        .setParameter(1, id)
+        .setParameter(2, kieli.name())
+        .setParameter(3, jobOpportunity)
+        .setParameter(4, description)
+        .setParameter(5, summary)
+        .setParameter(6, tasks)
+        .setParameter(7, requirements)
+        .executeUpdate();
+  }
+
+  @SuppressWarnings("java:S2699")
+  @Test
+  void shouldClearCacheAtStartup() {
+    mahdollisuudetService.clearCacheAtStartup();
+    // Note: This just verifies the method executes, as it's just clearing the cache
+  }
+
+  @Test
+  void shouldFetchTyoAndKoulutusMahdollisuusIdsWithTypes() {
+    var result =
+        mahdollisuudetService.fetchTyoAndKoulutusMahdollisuusIdsWithTypes(
+            Sort.Direction.ASC, Kieli.FI);
+
+    assertThat(result)
+        .as("Only actives should be included.")
+        .hasSize(2)
+        .containsEntry(koulutusIdActive, MahdollisuusTyyppi.KOULUTUSMAHDOLLISUUS)
+        .containsEntry(tyoIdActive, MahdollisuusTyyppi.TYOMAHDOLLISUUS);
+  }
+
+  @Test
+  void shouldFetchTyoAndKoulutusMahdollisuusIdsWithTypes_EmptyResults() {
+    var em = entityManager.getEntityManager();
+    em.createNativeQuery("DELETE FROM koulutusmahdollisuus_kaannos WHERE kaannos_key = 'EN'")
+        .executeUpdate();
+    em.createNativeQuery("DELETE FROM tyomahdollisuus_kaannos WHERE kaannos_key = 'EN'")
+        .executeUpdate();
+    entityManager.flush();
+
+    var result =
+        mahdollisuudetService.fetchTyoAndKoulutusMahdollisuusIdsWithTypes(
+            Sort.Direction.ASC, Kieli.EN);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/src/test/resources/data/mahdollisuudet-koulutus-delete-import-data.sql
+++ b/src/test/resources/data/mahdollisuudet-koulutus-delete-import-data.sql
@@ -1,0 +1,2 @@
+DELETE FROM koulutusmahdollisuus_data.import;
+DELETE FROM tyomahdollisuus_data.import;

--- a/src/test/resources/data/mahdollisuudet-koulutus-update-import-data-extended.sql
+++ b/src/test/resources/data/mahdollisuudet-koulutus-update-import-data-extended.sql
@@ -1,0 +1,163 @@
+UPDATE koulutusmahdollisuus_data.import
+SET data='{
+  "id": "30080e88-f292-48a3-9835-41950817abd3",
+  "luomisaika": "2022-05-02T12:06:55.818Z",
+  "tyyppi": "TUTKINTO",
+  "koulutukset": [
+    {
+      "oid": "1.2.246.562.13.00000000000000001767",
+      "nimi": {
+        "fi": "Psykologian maisteriohjelma, maisteri (2,5 v)",
+        "sv": "Masterprogram i psykologi, master (2,5 år)",
+        "en": "Master''s program in psychology, master''s (2.5 years)"
+      }
+    },
+    {
+      "oid": "1.2.246.562.13.00000000000000002956",
+      "nimi": {
+        "fi": "Psykologia, kandidaatti ja maisteri (3 v + 2,5/2 v)",
+        "sv": "Psykologi, kandidat- och masterexamen (3 år + 2,5/2 år)",
+        "en": "Psychology, bachelor''s and master''s (3 years + 2.5/2 years)"
+      }
+    },
+    {
+      "oid": "1.2.246.562.13.00000000000000002957",
+      "nimi": {
+        "fi": "Psykologia, kandidaatti ja maisteri (3 v + 2,5/2 v)",
+        "sv": "Psykologi, kandidat- och masterexamen (3 år + 2,5/2 år)",
+        "en": "Psychology, bachelor''s and master''s (3 years + 2.5/2 years)"
+      }
+    }
+  ],
+  "otsikko": {
+    "fi": "Uusi Psykologian yliopistotutkinto",
+    "sv": "Nya Kandidatexamen i psykologi",
+    "en": "New Degree in psychology"
+  },
+  "tiivistelma": {
+    "fi": "Psykologian yliopistotutkinto tutkii ihmismieltä, käyttäytymistä ja vuorovaikutusta. Keskeisiä aiheita ovat muun muassa kognitiivinen, sosiaalinen ja kehityspsykologia sekä neuro- ja kliininen psykologia. Opintoihin sisältyy teorian lisäksi tutkimusmenetelmiä, jotka valmistavat opiskelijoita tieteelliseen työhön ja uralle esimerkiksi kliinisinä psykologeina tai tutkijoina.",
+    "sv": "Universitetsexamen i psykologi studerar människans sinne, beteende och interaktion. Nyckelämnen inkluderar kognitiv, social och utvecklingspsykologi samt neuro- och klinisk psykologi. Studierna omfattar förutom teori forskningsmetoder som förbereder studenter för vetenskapligt arbete och karriärer, till exempel som klinisk psykolog eller forskare.",
+    "en": "The university degree in psychology studies the human mind, behavior and interaction. Key topics include cognitive, social and developmental psychology as well as neuro and clinical psychology. In addition to theory, the studies include research methods that prepare students for scientific work and careers, for example as clinical psychologists or researchers."
+  },
+  "kuvaus": {
+    "fi": "Psykologian yliopistotutkinto keskittyy ihmismielen, käyttäytymisen ja vuorovaikutuksen tutkimukseen. Koulutus tarjoaa laajan ymmärryksen siitä, miten ihmiset ajattelevat, tuntevat ja toimivat erilaisissa tilanteissa. Tutkinto koostuu teoreettisista opinnoista, käytännön harjoituksista ja tutkimustyöstä. Keskeisiä osa-alueita ovat muun muassa kognitiivinen psykologia, kehityspsykologia, sosiaalipsykologia, neuropsykologia, ja kliininen psykologia. Opintoihin kuuluu usein myös tutkimusmenetelmiä, kuten tilastotiedettä ja kokeellista tutkimusta, mikä auttaa psykologian opiskelijoita tekemään tieteellistä tutkimusta ja arvioimaan eri tutkimuslähteitä kriittisesti. Psykologian yliopistotutkinnon suorittaneet voivat työskennellä muun muassa kliinisinä psykologeina, organisaatiopsykologeina, tutkijoina tai henkilöstöhallinnon tehtävissä",
+    "sv": "Universitetsexamen i psykologi fokuserar på studiet av det mänskliga sinnet, beteende och interaktion. Utbildning ger en bred förståelse för hur människor tänker, känner och agerar i olika situationer. Examen består av teoretiska studier, praktiska övningar och forskningsarbete. Nyckelområden inkluderar kognitiv psykologi, utvecklingspsykologi, socialpsykologi, neuropsykologi och klinisk psykologi. Studier omfattar ofta även forskningsmetoder, som statistik och experimentell forskning, som hjälper psykologstudenter att bedriva vetenskaplig forskning och kritiskt värdera olika forskningskällor. Den som har avlagt en högskoleexamen i psykologi kan arbeta som klinisk psykolog, organisationspsykolog, forskare eller i personalledningspositioner t.ex.",
+    "en": "The university degree in psychology focuses on the study of the human mind, behavior and interaction. Education offers a broad understanding of how people think, feel and act in different situations. The degree consists of theoretical studies, practical exercises and research work. Key areas include cognitive psychology, developmental psychology, social psychology, neuropsychology, and clinical psychology. Studies often also include research methods, such as statistics and experimental research, which helps psychology students to conduct scientific research and critically evaluate different research sources. Those who have completed a university degree in psychology can work as clinical psychologists, organizational psychologists, researchers or in personnel management positions, for example"
+  },
+  "osaamiset": {
+    "kokonaismaara": 90,
+    "tyhjienMaara": 4,
+    "arvot": [
+      {
+        "arvo": "http://data.europa.eu/esco/skill/bfe4f330-d595-48c7-ab3c-f309471d6953",
+        "prosenttiosuus": 60
+      },
+      {
+        "arvo": "http://data.europa.eu/esco/skill/00920055-eb50-4cb8-a23d-3deedbf3753e",
+        "prosenttiosuus": 1
+      },
+      {
+        "arvo": "http://data.europa.eu/esco/skill/2618f336-8e71-4666-83b5-f368edb0906d",
+        "prosenttiosuus": 36
+      },
+      {
+        "arvo": "http://data.europa.eu/esco/skill/e9d8829d-5835-4100-a541-5c28b860cfc6",
+        "prosenttiosuus": 28
+      },
+      {
+        "arvo": "http://data.europa.eu/esco/skill/aec8ca21-4a5c-4ca6-ab60-939580010d39",
+        "prosenttiosuus": 25
+      }
+    ]
+  },
+  "koulutusalaJakauma": {
+    "kokonaismaara": 100,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "kansallinenkoulutusluokitus2016koulutusalataso2_031",
+        "prosenttiosuus": 70
+      },
+      {
+        "arvo": "kansallinenkoulutusluokitus2016koulutusalataso2_011",
+        "prosenttiosuus": 30
+      }
+    ]
+  },
+  "kestoMediaani": 51,
+  "kestoMinimi": 6,
+  "kestoMaksimi": 121,
+  "maksullisuusJakauma": {
+    "kokonaismaara": 18,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "maksullinen",
+        "prosenttiosuus": 50
+      },
+      {
+        "arvo": "maksuton",
+        "prosenttiosuus": 30
+      },
+      {
+        "arvo": "lukuvuosimaksu",
+        "prosenttiosuus": 20
+      }
+    ]
+  },
+  "opetustapaJakauma": {
+    "kokonaismaara": 18,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "opetuspaikkakk_2#1",
+        "prosenttiosuus": 50
+      },
+      {
+        "arvo": "opetuspaikkakk_1#1",
+        "prosenttiosuus": 30
+      },
+      {
+        "arvo": "opetuspaikkakk_2#2",
+        "prosenttiosuus": 20
+      }
+    ]
+  },
+  "aikaJakauma": {
+    "kokonaismaara": 18,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "opetusaikakk_2#1",
+        "prosenttiosuus": 50
+      },
+      {
+        "arvo": "opetusaikakk_1#1",
+        "prosenttiosuus": 30
+      },
+      {
+        "arvo": "opetusaikakk_2#2",
+        "prosenttiosuus": 20
+      }
+    ]
+  },
+  "kuntaJakauma": {
+    "kokonaismaara": 18,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "Helsinki",
+        "prosenttiosuus": 50
+      },
+      {
+        "arvo": "Espoo",
+        "prosenttiosuus": 30
+      },
+      {
+        "arvo": "Vantaa",
+        "prosenttiosuus": 20
+      }
+    ]
+  }
+}'
+WHERE id = '30080e88-f292-48a3-9835-41950817abd3'::uuid;

--- a/src/test/resources/data/mahdollisuudet-koulutus-update-import-data-reduced.sql
+++ b/src/test/resources/data/mahdollisuudet-koulutus-update-import-data-reduced.sql
@@ -1,0 +1,128 @@
+UPDATE koulutusmahdollisuus_data.import
+SET data='{
+  "id": "30080e88-f292-48a3-9835-41950817abd3",
+  "luomisaika": "2022-05-02T12:06:55.818Z",
+  "tyyppi": "TUTKINTO",
+  "koulutukset": [
+    {
+      "oid": "1.2.246.562.13.00000000000000001767",
+      "nimi": {
+        "fi": "Psykologian maisteriohjelma, maisteri (2,5 v)",
+        "en": "Master''s program in psychology, master''s (2.5 years)"
+      }
+    }
+  ],
+  "otsikko": {
+    "fi": "Uusi Psykologian yliopistotutkinto",
+    "sv": "Nya Kandidatexamen i psykologi",
+    "en": "New Degree in psychology"
+  },
+  "tiivistelma": {
+    "fi": "Psykologian yliopistotutkinto tutkii ihmismieltä, käyttäytymistä ja vuorovaikutusta. Keskeisiä aiheita ovat muun muassa kognitiivinen, sosiaalinen ja kehityspsykologia sekä neuro- ja kliininen psykologia. Opintoihin sisältyy teorian lisäksi tutkimusmenetelmiä, jotka valmistavat opiskelijoita tieteelliseen työhön ja uralle esimerkiksi kliinisinä psykologeina tai tutkijoina.",
+    "sv": "Universitetsexamen i psykologi studerar människans sinne, beteende och interaktion. Nyckelämnen inkluderar kognitiv, social och utvecklingspsykologi samt neuro- och klinisk psykologi. Studierna omfattar förutom teori forskningsmetoder som förbereder studenter för vetenskapligt arbete och karriärer, till exempel som klinisk psykolog eller forskare.",
+    "en": "The university degree in psychology studies the human mind, behavior and interaction. Key topics include cognitive, social and developmental psychology as well as neuro and clinical psychology. In addition to theory, the studies include research methods that prepare students for scientific work and careers, for example as clinical psychologists or researchers."
+  },
+  "kuvaus": {
+    "fi": "Psykologian yliopistotutkinto keskittyy ihmismielen, käyttäytymisen ja vuorovaikutuksen tutkimukseen. Koulutus tarjoaa laajan ymmärryksen siitä, miten ihmiset ajattelevat, tuntevat ja toimivat erilaisissa tilanteissa. Tutkinto koostuu teoreettisista opinnoista, käytännön harjoituksista ja tutkimustyöstä. Keskeisiä osa-alueita ovat muun muassa kognitiivinen psykologia, kehityspsykologia, sosiaalipsykologia, neuropsykologia, ja kliininen psykologia. Opintoihin kuuluu usein myös tutkimusmenetelmiä, kuten tilastotiedettä ja kokeellista tutkimusta, mikä auttaa psykologian opiskelijoita tekemään tieteellistä tutkimusta ja arvioimaan eri tutkimuslähteitä kriittisesti. Psykologian yliopistotutkinnon suorittaneet voivat työskennellä muun muassa kliinisinä psykologeina, organisaatiopsykologeina, tutkijoina tai henkilöstöhallinnon tehtävissä",
+    "sv": "Universitetsexamen i psykologi fokuserar på studiet av det mänskliga sinnet, beteende och interaktion. Utbildning ger en bred förståelse för hur människor tänker, känner och agerar i olika situationer. Examen består av teoretiska studier, praktiska övningar och forskningsarbete. Nyckelområden inkluderar kognitiv psykologi, utvecklingspsykologi, socialpsykologi, neuropsykologi och klinisk psykologi. Studier omfattar ofta även forskningsmetoder, som statistik och experimentell forskning, som hjälper psykologstudenter att bedriva vetenskaplig forskning och kritiskt värdera olika forskningskällor. Den som har avlagt en högskoleexamen i psykologi kan arbeta som klinisk psykolog, organisationspsykolog, forskare eller i personalledningspositioner t.ex.",
+    "en": "The university degree in psychology focuses on the study of the human mind, behavior and interaction. Education offers a broad understanding of how people think, feel and act in different situations. The degree consists of theoretical studies, practical exercises and research work. Key areas include cognitive psychology, developmental psychology, social psychology, neuropsychology, and clinical psychology. Studies often also include research methods, such as statistics and experimental research, which helps psychology students to conduct scientific research and critically evaluate different research sources. Those who have completed a university degree in psychology can work as clinical psychologists, organizational psychologists, researchers or in personnel management positions, for example"
+  },
+  "osaamiset": {
+    "kokonaismaara": 90,
+    "tyhjienMaara": 4,
+    "arvot": [
+      {
+        "arvo": "http://data.europa.eu/esco/skill/00920055-eb50-4cb8-a23d-3deedbf3753e",
+        "prosenttiosuus": 1
+      },
+      {
+        "arvo": "http://data.europa.eu/esco/skill/2618f336-8e71-4666-83b5-f368edb0906d",
+        "prosenttiosuus": 36
+      },
+      {
+        "arvo": "http://data.europa.eu/esco/skill/e9d8829d-5835-4100-a541-5c28b860cfc6",
+        "prosenttiosuus": 28
+      },
+      {
+        "arvo": "http://data.europa.eu/esco/skill/aec8ca21-4a5c-4ca6-ab60-939580010d39",
+        "prosenttiosuus": 25
+      }
+    ]
+  },
+  "kestoMediaani": 51,
+  "kestoMinimi": 6,
+  "kestoMaksimi": 121,
+  "maksullisuusJakauma": {
+    "kokonaismaara": 18,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "maksullinen",
+        "prosenttiosuus": 50
+      },
+      {
+        "arvo": "maksuton",
+        "prosenttiosuus": 30
+      },
+      {
+        "arvo": "lukuvuosimaksu",
+        "prosenttiosuus": 20
+      }
+    ]
+  },
+  "opetustapaJakauma": {
+    "kokonaismaara": 18,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "opetuspaikkakk_2#1",
+        "prosenttiosuus": 50
+      },
+      {
+        "arvo": "opetuspaikkakk_1#1",
+        "prosenttiosuus": 30
+      },
+      {
+        "arvo": "opetuspaikkakk_2#2",
+        "prosenttiosuus": 20
+      }
+    ]
+  },
+  "aikaJakauma": {
+    "kokonaismaara": 18,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "opetusaikakk_2#1",
+        "prosenttiosuus": 50
+      },
+      {
+        "arvo": "opetusaikakk_1#1",
+        "prosenttiosuus": 30
+      },
+      {
+        "arvo": "opetusaikakk_2#2",
+        "prosenttiosuus": 20
+      }
+    ]
+  },
+  "kuntaJakauma": {
+    "kokonaismaara": 18,
+    "tyhjienMaara": 5,
+    "arvot": [
+      {
+        "arvo": "Helsinki",
+        "prosenttiosuus": 50
+      },
+      {
+        "arvo": "Espoo",
+        "prosenttiosuus": 30
+      },
+      {
+        "arvo": "Vantaa",
+        "prosenttiosuus": 20
+      }
+    ]
+  }
+}'
+WHERE id = '30080e88-f292-48a3-9835-41950817abd3'::uuid;

--- a/src/test/resources/data/mahdollisuudet-tyo-delete-import-data.sql
+++ b/src/test/resources/data/mahdollisuudet-tyo-delete-import-data.sql
@@ -1,0 +1,2 @@
+DELETE FROM koulutusmahdollisuus_data.import;
+DELETE FROM tyomahdollisuus_data.import;

--- a/src/test/resources/data/mahdollisuudet-tyo-update-import-data-extended.sql
+++ b/src/test/resources/data/mahdollisuudet-tyo-update-import-data-extended.sql
@@ -1,0 +1,482 @@
+UPDATE tyomahdollisuus_data.import
+SET data='{
+  "id": "bc77f514-8573-11ef-8f0c-b767f527df04",
+  "luomisaika": "2024-08-20T00:00:00Z",
+  "aineisto": "AMMATTITIETO",
+  "tyopaikkailmoitukset": [
+    {
+      "ilmoittajanYTunnus": "1234567-8",
+      "ilmoituksenID": 12345678,
+      "julkaisupvm": "2000-01-01T00:00:00Z"
+    }
+  ],
+  "ammattiryhma": "http://data.europa.eu/esco/isco/C2149",
+  "osaamisvaatimukset": {
+    "ammatit": {
+      "kokonaismaara": 30,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/20786e6d-36f0-4d1e-b033-05101fa71f3c",
+          "prosenttiosuus": 30.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/21f4eb29-f6e5-4623-acb9-f3ff9c2f525d",
+          "prosenttiosuus": 12.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/2412bbb1-29ca-4e17-a2b8-70694f0cb14f",
+          "prosenttiosuus": 95.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/3d0f86c1-9bdd-4e84-bc62-93a716128c8d",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/4e82464b-e9d7-4d51-9116-294ab40c5169",
+          "prosenttiosuus": 45.83333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/653374a9-a96e-4c5b-849f-62ae67b0ed62",
+          "prosenttiosuus": 33.33333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/6afe39e2-2674-45db-b05c-a6cab02fe25b",
+          "prosenttiosuus": 45.83333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/a6517365-211c-456d-aca4-1a0115c7b1e1",
+          "prosenttiosuus": 25.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/a9c30651-ccbc-4a80-900c-7880615cdf6e",
+          "prosenttiosuus": 95.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/abab3d6a-82b9-49bd-8a4b-7bc678130558",
+          "prosenttiosuus": 70.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/ec5b72d1-0206-4179-9abd-570c66bc44b9",
+          "prosenttiosuus": 4.166666666666666
+        }
+      ]
+    },
+    "osaamiset": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "http://data.europa.eu/esco/skill/078098e1-01f7-4654-9ddd-016f4063b54d",
+          "prosenttiosuus": 79.16666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/09f159aa-2745-4ab0-a050-96722a2269b9",
+          "prosenttiosuus": 95.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/0ffed47f-d320-48cf-988d-40449825085c",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/11f536f5-b0e2-46a6-95c1-bd765946604c",
+          "prosenttiosuus": 87.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/135192cb-84e4-4b70-8946-fbe5041b26cd",
+          "prosenttiosuus": 83.33333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/14dc991f-1b21-413d-86a3-499e6676abb9",
+          "prosenttiosuus": 16.666666666666664
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/31b67516-af16-4b97-8430-a8a8e0f84190",
+          "prosenttiosuus": 100.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/36fe44b2-af36-4467-9be8-601e64b3dbc7",
+          "prosenttiosuus": 87.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/3cd304db-9df0-4f22-9759-9ed86155876c",
+          "prosenttiosuus": 37.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/3fcc49e8-71f8-4265-9e48-2e8c3465340a",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/415abd43-e8e5-4643-b5da-5f11307af57a",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/4dafe480-f2ae-46b5-bd5e-8d4e538f50c7",
+          "prosenttiosuus": 83.33333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/573d3f91-c81c-407e-a56d-0f3a63272b43",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/57beaad1-7c5e-4b17-a35f-31f49e1d7378",
+          "prosenttiosuus": 95.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/59eb177a-2f30-4943-8b30-5f87dd51a80d",
+          "prosenttiosuus": 87.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/5de0599a-8fca-4cdd-a72d-f5d21af8eeb3",
+          "prosenttiosuus": 58.333333333333336
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/60856bbb-e5db-4398-babb-300a24a7fe97",
+          "prosenttiosuus": 70.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/6fe019dd-027f-45f3-b19c-d27f7ae00980",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/731101d9-94bc-4805-bff4-9578d1bf03b5",
+          "prosenttiosuus": 100.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/74bb0643-a15f-48ea-b12c-d98bf49cb317",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/7c89d065-c50d-4129-b963-b73e62e58ba4",
+          "prosenttiosuus": 91.66666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/7d23c508-c007-4221-bb84-0c9a479b8ea6",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/860e85ee-5992-445a-b3d3-9bab524f7600",
+          "prosenttiosuus": 37.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/8af15e52-c743-43da-94aa-c4ea52d4f3e8",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/8e839bce-38f0-472d-8792-9b7c12b197ef",
+          "prosenttiosuus": 79.16666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/97db841c-31bf-4aa0-85b9-0ddd0a77b7a5",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/9df34bc3-25d4-4452-a896-4d19b94ef896",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/a17286c5-238d-4f0b-bc24-29e9121345de",
+          "prosenttiosuus": 45.83333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/a87c1c42-8927-4183-97c7-a17554c22b29",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/b9bb1f03-15e2-4079-943e-7e483b21725b",
+          "prosenttiosuus": 33.33333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/c4f8c22a-63f2-47d5-9721-d560f1f042b8",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/d4789070-2ff7-4bbb-94ca-8bb1739826a9",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/d5e1e30e-44ab-4aba-abab-b8263e801b7a",
+          "prosenttiosuus": 91.66666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/d87fe0be-9055-4a76-a444-e98b5bfad9d8",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/dc298fac-7ab4-4feb-9b43-33d947d7703e",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/e3145bd7-7f35-44ec-a5dc-4417c5c9ab9a",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/e9160feb-109a-41eb-9604-9f898c710d0f",
+          "prosenttiosuus": 29.166666666666668
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/ed57378a-2b27-4d80-8701-124e559cf17d",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/edff6d20-660d-4d33-b412-9a5b664a14be",
+          "prosenttiosuus": 75.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/efa7a6e9-3018-4125-8ac5-5b5d513bcba7",
+          "prosenttiosuus": 29.166666666666668
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/f524f72e-d3d0-4691-9c57-d19756d8b847",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/f5dc20ae-8b2f-4c9b-b4fa-e9e8c81dbcf4",
+          "prosenttiosuus": 83.33333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/f7940b22-764a-43f0-9642-f60f5897109b",
+          "prosenttiosuus": 20.833333333333336
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/fd88851f-4d1d-4de8-aee1-4464c3012969",
+          "prosenttiosuus": 91.66666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/fddc5d4f-0dfe-42fb-a1c0-3ad827db2216",
+          "prosenttiosuus": 4.166666666666666
+        }
+      ]
+    },
+    "ajokorttiJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": []
+    },
+    "kielitaitoJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 24,
+      "arvot": []
+    },
+    "kortitJaLuvatJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": []
+    },
+    "koulutusasteJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 24,
+      "arvot": []
+    },
+    "rikosrekisterioteJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": 0,
+          "prosenttiosuus": 100.0
+        }
+      ]
+    }
+  },
+  "perustiedot": {
+    "matkustamisvaatimusJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": 0,
+          "prosenttiosuus": 100.0
+        }
+      ]
+    },
+    "palkanPerusteJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "OTHER",
+          "prosenttiosuus": 100.0
+        }
+      ]
+    },
+    "palvelussuhdeJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "EMPLOYMENT",
+          "prosenttiosuus": 100.0
+        }
+      ]
+    },
+    "tyoaikaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "FULLTIME",
+          "prosenttiosuus": 75.0
+        },
+        {
+          "arvo": "PARTTIME",
+          "prosenttiosuus": 25.0
+        }
+      ]
+    },
+    "tyonJatkuvuusJakauma": {
+      "kokonaismaara": 30,
+      "tyhjienMaara": 1,
+      "arvot": [
+        {
+          "arvo": "PERMANENT",
+          "prosenttiosuus": 80.5
+        },
+        {
+          "arvo": "TEMPORARY",
+          "prosenttiosuus": 19.5
+        }
+      ]
+    },
+    "tyomahdollisuudenKuvaus": {
+      "fi": "Kuvaus",
+      "sv": "Kuvaus",
+      "en": "Kuvaus"
+    },
+    "tyomahdollisuudenOtsikko": {
+      "fi": "Uusi Kouluttaja",
+      "sv": "Nya Kouluttaja",
+      "en": "New Kouluttaja"
+    },
+    "tyomahdollisuudenTiivistelma": {
+      "fi": "Tiivistelmä",
+      "sv": "Tiivistelmä",
+      "en": "Tiivistelmä"
+    }
+  },
+  "sijainti": {
+    "kuntaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "049",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "091",
+          "prosenttiosuus": 20.833333333333336
+        },
+        {
+          "arvo": "092",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 109,
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": 167,
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": 179,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 202,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 698,
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": 837,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 853,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 905,
+          "prosenttiosuus": 4.166666666666666
+        }
+      ]
+    },
+    "maaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "FI",
+          "prosenttiosuus": 100.0
+        }
+      ]
+    },
+    "maakuntaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "01",
+          "prosenttiosuus": 33.33333333333333
+        },
+        {
+          "arvo": "02",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "05",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "06",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 12,
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": 13,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 15,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 19,
+          "prosenttiosuus": 8.333333333333332
+        }
+      ]
+    },
+    "sijaintiJoustavaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": 0,
+          "prosenttiosuus": 62.5
+        },
+        {
+          "arvo": 1,
+          "prosenttiosuus": 37.5
+        }
+      ]
+    }
+  },
+  "tyokieletJakauma": {
+    "kokonaismaara": 24,
+    "tyhjienMaara": 0,
+    "arvot": [
+      {
+        "arvo": "fi",
+        "prosenttiosuus": 12.5
+      }
+    ]
+  }
+}'
+WHERE id = 'bc77f514-8573-11ef-8f0c-b767f527df04'::uuid;

--- a/src/test/resources/data/mahdollisuudet-tyo-update-import-data-reduced.sql
+++ b/src/test/resources/data/mahdollisuudet-tyo-update-import-data-reduced.sql
@@ -1,0 +1,477 @@
+UPDATE tyomahdollisuus_data.import
+SET data='{
+  "id": "bc77f514-8573-11ef-8f0c-b767f527df04",
+  "luomisaika": "2024-08-20T00:00:00Z",
+  "aineisto": "AMMATTITIETO",
+  "tyopaikkailmoitukset": [
+    {
+      "ilmoittajanYTunnus": "1234567-8",
+      "ilmoituksenID": 12345678,
+      "julkaisupvm": "2000-01-01T00:00:00Z"
+    },
+    {
+      "ilmoittajanYTunnus": "2234567-8",
+      "ilmoituksenID": 22345678,
+      "julkaisupvm": "3000-01-01T00:00:00Z"
+    }
+  ],
+  "ammattiryhma": "http://data.europa.eu/esco/isco/C2149",
+  "osaamisvaatimukset": {
+    "ammatit": {
+      "kokonaismaara": 30,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/20786e6d-36f0-4d1e-b033-05101fa71f3c",
+          "prosenttiosuus": 30.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/21f4eb29-f6e5-4623-acb9-f3ff9c2f525d",
+          "prosenttiosuus": 12.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/2412bbb1-29ca-4e17-a2b8-70694f0cb14f",
+          "prosenttiosuus": 95.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/3d0f86c1-9bdd-4e84-bc62-93a716128c8d",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/4e82464b-e9d7-4d51-9116-294ab40c5169",
+          "prosenttiosuus": 45.83333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/653374a9-a96e-4c5b-849f-62ae67b0ed62",
+          "prosenttiosuus": 33.33333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/6afe39e2-2674-45db-b05c-a6cab02fe25b",
+          "prosenttiosuus": 45.83333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/a6517365-211c-456d-aca4-1a0115c7b1e1",
+          "prosenttiosuus": 25.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/a9c30651-ccbc-4a80-900c-7880615cdf6e",
+          "prosenttiosuus": 95.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/abab3d6a-82b9-49bd-8a4b-7bc678130558",
+          "prosenttiosuus": 70.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/occupation/ec5b72d1-0206-4179-9abd-570c66bc44b9",
+          "prosenttiosuus": 4.166666666666666
+        }
+      ]
+    },
+    "osaamiset": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "http://data.europa.eu/esco/skill/078098e1-01f7-4654-9ddd-016f4063b54d",
+          "prosenttiosuus": 79.16666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/09f159aa-2745-4ab0-a050-96722a2269b9",
+          "prosenttiosuus": 95.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/0ffed47f-d320-48cf-988d-40449825085c",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/11f536f5-b0e2-46a6-95c1-bd765946604c",
+          "prosenttiosuus": 87.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/135192cb-84e4-4b70-8946-fbe5041b26cd",
+          "prosenttiosuus": 83.33333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/14dc991f-1b21-413d-86a3-499e6676abb9",
+          "prosenttiosuus": 16.666666666666664
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/31b67516-af16-4b97-8430-a8a8e0f84190",
+          "prosenttiosuus": 100.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/36fe44b2-af36-4467-9be8-601e64b3dbc7",
+          "prosenttiosuus": 87.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/3cd304db-9df0-4f22-9759-9ed86155876c",
+          "prosenttiosuus": 37.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/3fcc49e8-71f8-4265-9e48-2e8c3465340a",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/415abd43-e8e5-4643-b5da-5f11307af57a",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/4dafe480-f2ae-46b5-bd5e-8d4e538f50c7",
+          "prosenttiosuus": 83.33333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/573d3f91-c81c-407e-a56d-0f3a63272b43",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/57beaad1-7c5e-4b17-a35f-31f49e1d7378",
+          "prosenttiosuus": 95.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/59eb177a-2f30-4943-8b30-5f87dd51a80d",
+          "prosenttiosuus": 87.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/5de0599a-8fca-4cdd-a72d-f5d21af8eeb3",
+          "prosenttiosuus": 58.333333333333336
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/60856bbb-e5db-4398-babb-300a24a7fe97",
+          "prosenttiosuus": 70.83333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/6fe019dd-027f-45f3-b19c-d27f7ae00980",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/731101d9-94bc-4805-bff4-9578d1bf03b5",
+          "prosenttiosuus": 100.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/74bb0643-a15f-48ea-b12c-d98bf49cb317",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/7c89d065-c50d-4129-b963-b73e62e58ba4",
+          "prosenttiosuus": 91.66666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/7d23c508-c007-4221-bb84-0c9a479b8ea6",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/860e85ee-5992-445a-b3d3-9bab524f7600",
+          "prosenttiosuus": 37.5
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/8af15e52-c743-43da-94aa-c4ea52d4f3e8",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/8e839bce-38f0-472d-8792-9b7c12b197ef",
+          "prosenttiosuus": 79.16666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/97db841c-31bf-4aa0-85b9-0ddd0a77b7a5",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/9df34bc3-25d4-4452-a896-4d19b94ef896",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/a17286c5-238d-4f0b-bc24-29e9121345de",
+          "prosenttiosuus": 45.83333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/a87c1c42-8927-4183-97c7-a17554c22b29",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/b9bb1f03-15e2-4079-943e-7e483b21725b",
+          "prosenttiosuus": 33.33333333333333
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/c4f8c22a-63f2-47d5-9721-d560f1f042b8",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/d4789070-2ff7-4bbb-94ca-8bb1739826a9",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/d5e1e30e-44ab-4aba-abab-b8263e801b7a",
+          "prosenttiosuus": 91.66666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/d87fe0be-9055-4a76-a444-e98b5bfad9d8",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/dc298fac-7ab4-4feb-9b43-33d947d7703e",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/e3145bd7-7f35-44ec-a5dc-4417c5c9ab9a",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/e9160feb-109a-41eb-9604-9f898c710d0f",
+          "prosenttiosuus": 29.166666666666668
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/ed57378a-2b27-4d80-8701-124e559cf17d",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/edff6d20-660d-4d33-b412-9a5b664a14be",
+          "prosenttiosuus": 75.0
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/efa7a6e9-3018-4125-8ac5-5b5d513bcba7",
+          "prosenttiosuus": 29.166666666666668
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/f524f72e-d3d0-4691-9c57-d19756d8b847",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/f5dc20ae-8b2f-4c9b-b4fa-e9e8c81dbcf4",
+          "prosenttiosuus": 83.33333333333334
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/f7940b22-764a-43f0-9642-f60f5897109b",
+          "prosenttiosuus": 20.833333333333336
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/fd88851f-4d1d-4de8-aee1-4464c3012969",
+          "prosenttiosuus": 91.66666666666666
+        },
+        {
+          "arvo": "http://data.europa.eu/esco/skill/fddc5d4f-0dfe-42fb-a1c0-3ad827db2216",
+          "prosenttiosuus": 4.166666666666666
+        }
+      ]
+    },
+    "kielitaitoJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 24,
+      "arvot": []
+    },
+    "kortitJaLuvatJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": []
+    },
+    "koulutusasteJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 24,
+      "arvot": []
+    },
+    "rikosrekisterioteJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": 0,
+          "prosenttiosuus": 100.0
+        }
+      ]
+    }
+  },
+  "perustiedot": {
+    "matkustamisvaatimusJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": 0,
+          "prosenttiosuus": 100.0
+        }
+      ]
+    },
+    "palkanPerusteJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "OTHER",
+          "prosenttiosuus": 100.0
+        }
+      ]
+    },
+    "palvelussuhdeJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "EMPLOYMENT",
+          "prosenttiosuus": 100.0
+        }
+      ]
+    },
+    "tyoaikaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "FULLTIME",
+          "prosenttiosuus": 75.0
+        },
+        {
+          "arvo": "PARTTIME",
+          "prosenttiosuus": 25.0
+        }
+      ]
+    },
+    "tyonJatkuvuusJakauma": {
+      "kokonaismaara": 30,
+      "tyhjienMaara": 1,
+      "arvot": [
+        {
+          "arvo": "TEMPORARY",
+          "prosenttiosuus": 100
+        }
+      ]
+    },
+    "tyomahdollisuudenKuvaus": {
+      "fi": "Kuvaus",
+      "sv": "Kuvaus",
+      "en": "Kuvaus"
+    },
+    "tyomahdollisuudenOtsikko": {
+      "fi": "Uusi Kouluttaja",
+      "en": "New Kouluttaja"
+    },
+    "tyomahdollisuudenTiivistelma": {
+      "fi": "Tiivistelmä",
+      "sv": "Tiivistelmä",
+      "en": "Tiivistelmä"
+    }
+  },
+  "sijainti": {
+    "kuntaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "049",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "091",
+          "prosenttiosuus": 20.833333333333336
+        },
+        {
+          "arvo": "092",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 109,
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": 167,
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": 179,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 202,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 698,
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": 837,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 853,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 905,
+          "prosenttiosuus": 4.166666666666666
+        }
+      ]
+    },
+    "maaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "FI",
+          "prosenttiosuus": 100.0
+        }
+      ]
+    },
+    "maakuntaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": "01",
+          "prosenttiosuus": 33.33333333333333
+        },
+        {
+          "arvo": "02",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "05",
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": "06",
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 12,
+          "prosenttiosuus": 8.333333333333332
+        },
+        {
+          "arvo": 13,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 15,
+          "prosenttiosuus": 4.166666666666666
+        },
+        {
+          "arvo": 19,
+          "prosenttiosuus": 8.333333333333332
+        }
+      ]
+    },
+    "sijaintiJoustavaJakauma": {
+      "kokonaismaara": 24,
+      "tyhjienMaara": 0,
+      "arvot": [
+        {
+          "arvo": 0,
+          "prosenttiosuus": 62.5
+        },
+        {
+          "arvo": 1,
+          "prosenttiosuus": 37.5
+        }
+      ]
+    }
+  },
+  "tyokieletJakauma": {
+    "kokonaismaara": 24,
+    "tyhjienMaara": 0,
+    "arvot": [
+      {
+        "arvo": "fi",
+        "prosenttiosuus": 12.5
+      }
+    ]
+  }
+}'
+WHERE id = 'bc77f514-8573-11ef-8f0c-b767f527df04'::uuid;


### PR DESCRIPTION
## Description

- Added upsert logic to maintain record activity (`Tyomahdollisuus` and `Koulutusmahdollisuus`).
- Introduced an `aktiivinen` boolean field with a default value of true for both entities.
- Applied `@SQLRestriction` to exclude inactive records in database queries.
- Refactored data import and upsert logic for `Tyomahdollisuus` and `Koulutusmahdollisuus`, ensuring outdated records are marked inactive.
- Added tests to verify both `tyomahdollisuus_data.import` and `koulutusmahdollisuus_data.import` SQL procedures.
- Updated unique constraint names and entity structures.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1410