### PR TITLE
OPHJOD-1063: Set 'development' as default environment in deploy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy-dev:
+  deploy-development:
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: package
     uses: ./.github/workflows/deploy.yml
@@ -137,14 +137,14 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      environment: dev
+      environment: development
       tag: ${{ needs.package.outputs.tag }}
 
   deploy-test:
     if: github.ref == 'refs/heads/main'
     needs:
       - package
-      - deploy-dev
+      - deploy-development
     uses: ./.github/workflows/deploy.yml
     permissions:
       id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,9 @@ on:
         type: choice
         description: 'Environment to deploy to'
         required: true
-        default: 'dev'
+        default: 'development'
         options:
-          - dev
+          - development
           - test
       tag:
         type: string


### PR DESCRIPTION
## Description

- Updated the default environment from 'dev' to 'development' in the deploy workflow YAML file. This change ensures consistency with the naming conventions across configuration settings.
- Added "Development" in https://github.com/Opetushallitus/jod-yksilo/settings/environments

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-106