### PR TITLE
OPHJOD-1545: Add `lahde` field to `PolunVaihe` entities and DTOs

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/domain/PolunVaiheLahde.java
+++ b/src/main/java/fi/okm/jod/yksilo/domain/PolunVaiheLahde.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.domain;
+
+public enum PolunVaiheLahde {
+  EHDOTUS,
+  KAYTTAJA
+}

--- a/src/main/java/fi/okm/jod/yksilo/dto/profiili/PolunVaiheDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/profiili/PolunVaiheDto.java
@@ -12,6 +12,7 @@ package fi.okm.jod.yksilo.dto.profiili;
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 import fi.okm.jod.yksilo.domain.LocalizedString;
+import fi.okm.jod.yksilo.domain.PolunVaiheLahde;
 import fi.okm.jod.yksilo.domain.PolunVaiheTyyppi;
 import fi.okm.jod.yksilo.dto.validationgroup.Add;
 import fi.okm.jod.yksilo.validation.PrintableString;
@@ -27,6 +28,7 @@ import java.util.UUID;
 
 public record PolunVaiheDto(
     @Null(groups = Add.class) @Schema(accessMode = READ_ONLY) UUID id,
+    @NotNull PolunVaiheLahde lahde,
     @NotNull PolunVaiheTyyppi tyyppi,
     @NotEmpty @PrintableString @Size(max = 200) LocalizedString nimi,
     @PrintableString @Size(max = 10000) LocalizedString kuvaus,

--- a/src/main/java/fi/okm/jod/yksilo/dto/profiili/export/PolunVaiheExportDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/profiili/export/PolunVaiheExportDto.java
@@ -10,6 +10,7 @@
 package fi.okm.jod.yksilo.dto.profiili.export;
 
 import fi.okm.jod.yksilo.domain.LocalizedString;
+import fi.okm.jod.yksilo.domain.PolunVaiheLahde;
 import fi.okm.jod.yksilo.domain.PolunVaiheTyyppi;
 import java.net.URI;
 import java.time.LocalDate;
@@ -18,6 +19,7 @@ import java.util.UUID;
 
 public record PolunVaiheExportDto(
     UUID id,
+    PolunVaiheLahde lahde,
     PolunVaiheTyyppi tyyppi,
     LocalizedString nimi,
     LocalizedString kuvaus,

--- a/src/main/java/fi/okm/jod/yksilo/entity/PolunVaihe.java
+++ b/src/main/java/fi/okm/jod/yksilo/entity/PolunVaihe.java
@@ -14,6 +14,7 @@ import static java.util.Objects.requireNonNull;
 
 import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.domain.LocalizedString;
+import fi.okm.jod.yksilo.domain.PolunVaiheLahde;
 import fi.okm.jod.yksilo.domain.PolunVaiheTyyppi;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Basic;
@@ -54,6 +55,11 @@ public class PolunVaihe {
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(updatable = false, nullable = false)
   private PolunSuunnitelma polunSuunnitelma;
+
+  @Setter
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private PolunVaiheLahde lahde;
 
   @Setter
   @Column(nullable = false)

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/ExportMapper.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/ExportMapper.java
@@ -33,6 +33,9 @@ import fi.okm.jod.yksilo.entity.Toiminto;
 import fi.okm.jod.yksilo.entity.Tyopaikka;
 import fi.okm.jod.yksilo.entity.Yksilo;
 import fi.okm.jod.yksilo.entity.YksilonSuosikki;
+import fi.okm.jod.yksilo.entity.koulutusmahdollisuus.Koulutusmahdollisuus;
+import fi.okm.jod.yksilo.entity.tyomahdollisuus.Tyomahdollisuus;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public final class ExportMapper {
@@ -151,11 +154,17 @@ public final class ExportMapper {
         : new YksilonSuosikkiExportDto(
             entity.getId(),
             entity.getLuotu(),
-            entity.getTyomahdollisuus() != null ? entity.getTyomahdollisuus().getId() : null,
-            entity.getKoulutusmahdollisuus() != null
-                ? entity.getKoulutusmahdollisuus().getId()
-                : null,
+            getTyomahdollisuusId(entity.getTyomahdollisuus()),
+            getKoulutusmahdollisuusId(entity.getKoulutusmahdollisuus()),
             entity.getTyyppi());
+  }
+
+  private static UUID getTyomahdollisuusId(Tyomahdollisuus tyomahdollisuus) {
+    return tyomahdollisuus != null ? tyomahdollisuus.getId() : null;
+  }
+
+  private static UUID getKoulutusmahdollisuusId(Koulutusmahdollisuus koulutusmahdollisuus) {
+    return koulutusmahdollisuus != null ? koulutusmahdollisuus.getId() : null;
   }
 
   public static PaamaaraExportDto mapPaamaara(Paamaara entity) {
@@ -165,13 +174,9 @@ public final class ExportMapper {
             entity.getId(),
             entity.getLuotu(),
             entity.getTyyppi(),
-            entity.getTyomahdollisuus() != null ? entity.getTyomahdollisuus().getId() : null,
-            entity.getKoulutusmahdollisuus() != null
-                ? entity.getKoulutusmahdollisuus().getId()
-                : null,
-            entity.getSuunnitelmat().stream()
-                .map(ExportMapper::mapPolunSuunnitelma)
-                .collect(Collectors.toList()),
+            getTyomahdollisuusId(entity.getTyomahdollisuus()),
+            getKoulutusmahdollisuusId(entity.getKoulutusmahdollisuus()),
+            entity.getSuunnitelmat().stream().map(ExportMapper::mapPolunSuunnitelma).toList(),
             entity.getTavoite());
   }
 
@@ -181,9 +186,7 @@ public final class ExportMapper {
         : new PolunSuunnitelmaExportDto(
             entity.getId(),
             entity.getNimi(),
-            entity.getVaiheet().stream()
-                .map(ExportMapper::mapPolunVaihe)
-                .collect(Collectors.toList()),
+            entity.getVaiheet().stream().map(ExportMapper::mapPolunVaihe).toList(),
             entity.getOsaamiset().stream().map(Osaaminen::getUri).collect(Collectors.toSet()),
             entity.getIgnoredOsaamiset().stream()
                 .map(Osaaminen::getUri)
@@ -195,6 +198,7 @@ public final class ExportMapper {
         ? null
         : new PolunVaiheExportDto(
             entity.getId(),
+            entity.getLahde(),
             entity.getTyyppi(),
             entity.getNimi(),
             entity.getKuvaus(),

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/Mapper.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/Mapper.java
@@ -221,6 +221,7 @@ public final class Mapper {
         ? null
         : new PolunVaiheDto(
             entity.getId(),
+            entity.getLahde(),
             entity.getTyyppi(),
             entity.getNimi(),
             entity.getKuvaus(),

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/PolunVaiheService.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/PolunVaiheService.java
@@ -68,22 +68,19 @@ public class PolunVaiheService {
 
   private PolunVaihe add(PolunSuunnitelma polunSuunnitelma, PolunVaiheDto dto) {
     var entity = new PolunVaihe(polunSuunnitelma);
-    entity.setTyyppi(dto.tyyppi());
-    entity.setNimi(dto.nimi());
-    entity.setKuvaus(dto.kuvaus());
-    entity.setLinkit(dto.linkit());
-    entity.setAlkuPvm(dto.alkuPvm());
-    entity.setLoppuPvm(dto.loppuPvm());
-    if (dto.osaamiset() != null) {
-      entity.setOsaamiset(getOsaamiset(entity, dto));
-    }
-    entity.setValmis(dto.valmis());
+    updateEntityFieldFromDtoData(entity, dto);
     entity = vaiheRepository.save(entity);
 
     return entity;
   }
 
   private void update(PolunVaihe entity, PolunVaiheDto dto) {
+    updateEntityFieldFromDtoData(entity, dto);
+    vaiheRepository.save(entity);
+  }
+
+  private void updateEntityFieldFromDtoData(PolunVaihe entity, PolunVaiheDto dto) {
+    entity.setLahde(dto.lahde());
     entity.setTyyppi(dto.tyyppi());
     entity.setNimi(dto.nimi());
     entity.setKuvaus(dto.kuvaus());
@@ -94,7 +91,6 @@ public class PolunVaiheService {
       entity.setOsaamiset(getOsaamiset(entity, dto));
     }
     entity.setValmis(dto.valmis());
-    vaiheRepository.save(entity);
   }
 
   private void delete(PolunVaihe entity) {

--- a/src/test/java/fi/okm/jod/yksilo/service/profiili/ExportMapperTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/profiili/ExportMapperTest.java
@@ -135,10 +135,6 @@ class ExportMapperTest {
         PolunVaihe.class, PolunVaiheExportDto.class, Set.of("polunSuunnitelma"));
   }
 
-  private void assertMappingCompleteness(Class<?> entityClass, Class<?> dtoClass) {
-    assertMappingCompleteness(entityClass, dtoClass, Set.of());
-  }
-
   private void assertMappingCompleteness(
       Class<?> entityClass, Class<?> dtoClass, Set<String> ignoredGetters) {
     Set<String> entityGetters = getGetterNames(entityClass, ignoredGetters);

--- a/src/test/java/fi/okm/jod/yksilo/service/profiili/PolunVaiheServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/profiili/PolunVaiheServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mockStatic;
 
 import fi.okm.jod.yksilo.domain.MahdollisuusTyyppi;
 import fi.okm.jod.yksilo.domain.PaamaaraTyyppi;
+import fi.okm.jod.yksilo.domain.PolunVaiheLahde;
 import fi.okm.jod.yksilo.domain.PolunVaiheTyyppi;
 import fi.okm.jod.yksilo.dto.profiili.PaamaaraDto;
 import fi.okm.jod.yksilo.dto.profiili.PolunSuunnitelmaDto;
@@ -38,8 +39,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql("/data/osaaminen.sql")
-@Sql("/data/mahdollisuudet-test-data.sql")
+@Sql(
+    value = {"/data/osaaminen.sql", "/data/mahdollisuudet-test-data.sql"},
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
 @Import({
   PolunVaiheService.class,
   PolunSuunnitelmaService.class,
@@ -77,6 +79,7 @@ class PolunVaiheServiceTest extends AbstractServiceTest {
     var updatedDto =
         new PolunVaiheDto(
             id,
+            PolunVaiheLahde.KAYTTAJA,
             PolunVaiheTyyppi.TYO,
             ls("uusi nimi"),
             ls("uusi kuvaus"),
@@ -142,6 +145,7 @@ class PolunVaiheServiceTest extends AbstractServiceTest {
     var dto =
         new PolunVaiheDto(
             null,
+            PolunVaiheLahde.EHDOTUS,
             PolunVaiheTyyppi.KOULUTUS,
             ls("nimi"),
             ls("kuvaus"),
@@ -191,6 +195,7 @@ class PolunVaiheServiceTest extends AbstractServiceTest {
   private PolunVaiheDto createPolunVaiheDto(Set<URI> osaamiset) {
     return new PolunVaiheDto(
         null,
+        PolunVaiheLahde.KAYTTAJA,
         PolunVaiheTyyppi.KOULUTUS,
         ls("nimi"),
         ls("kuvaus"),


### PR DESCRIPTION
## Description

Added the `lahde` field to `PolunVaihe` entities and DTOs to distinguish creation types. Introduced `PolunVaiheLahde` enum, updated mappings, services, and tests to ensure support and data consistency.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1545