### PR TITLE
OPHJOD-2001: Limit maximum JSON request size

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/config/mapping/MappingConfig.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mapping/MappingConfig.java
@@ -10,6 +10,8 @@
 package fi.okm.jod.yksilo.config.mapping;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import fi.okm.jod.yksilo.domain.LocalizedString;
@@ -19,6 +21,12 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class MappingConfig {
+
+  // limits for acceptable JSON input sizes
+  public static final long MAX_DOC_LEN = 1024L * 1024L;
+  public static final int MAX_STRING_LEN = 32 * 1024;
+  public static final int MAX_NAME_LEN = 256;
+
   @Bean
   Jackson2ObjectMapperBuilderCustomizer customizer() {
     return builder ->
@@ -27,6 +35,15 @@ public class MappingConfig {
                 SerializationFeature.WRITE_ENUMS_USING_TO_STRING,
                 MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
             .serializationInclusion(JsonInclude.Include.NON_ABSENT)
-            .mixIn(LocalizedString.class, LocalizedStringMixin.class);
+            .mixIn(LocalizedString.class, LocalizedStringMixin.class)
+            .factory(
+                JsonFactory.builder()
+                    .streamReadConstraints(
+                        StreamReadConstraints.builder()
+                            .maxNameLength(MAX_NAME_LEN)
+                            .maxStringLength(MAX_STRING_LEN)
+                            .maxDocumentLength(MAX_DOC_LEN)
+                            .build())
+                    .build());
   }
 }

--- a/src/test/java/fi/okm/jod/yksilo/config/mapping/MappingConfigTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/config/mapping/MappingConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.config.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.annotation.Import;
+
+@JsonTest
+@Import(MappingConfig.class)
+class MappingConfigTest {
+  @Autowired ObjectMapper objectMapper;
+
+  @Test
+  void shouldEnforceStringLengthLimit() {
+    var str = "x".repeat(MappingConfig.MAX_STRING_LEN * 2);
+    var doc = "{\"field\":\"" + str + "\"}";
+    assertThrows(StreamConstraintsException.class, () -> objectMapper.readTree(doc));
+  }
+
+  @Test
+  void shouldEnforceDocumentSizeLimit() {
+    var elem = "\"" + "x".repeat(1024) + "\"";
+    int count =
+        (int) MappingConfig.MAX_DOC_LEN / (elem.length() + 1)
+            + 10 /* some margin as the limit is not exact */;
+    var doc = "[" + elem + ("," + elem).repeat(count - 1) + "]";
+
+    assertTrue(doc.length() > MappingConfig.MAX_DOC_LEN);
+    assertThrows(StreamConstraintsException.class, () -> objectMapper.readTree(doc));
+  }
+
+  @Test
+  void shouldAcceptValidDocument() {
+    var elem = "\"" + "x".repeat(1024) + "\"";
+    int count = (int) MappingConfig.MAX_DOC_LEN / (elem.length() + 1);
+    var tmp = "[" + elem + ("," + elem).repeat(count - 1);
+    tmp += ",\"" + "x".repeat((int) MappingConfig.MAX_DOC_LEN - tmp.length() - 4) + "\"]";
+    var doc = tmp;
+
+    assertEquals(MappingConfig.MAX_DOC_LEN, doc.length());
+    assertDoesNotThrow(() -> objectMapper.readTree(doc));
+  }
+}


### PR DESCRIPTION
## Description
Customizes default Objectmapper to enforce limits on JSON document size.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-2001
