### PR TITLE
OPHJOD-1842: Add email to user profile data

### DIFF
--- a/scripts/devdata/yksilot.sql
+++ b/scripts/devdata/yksilot.sql
@@ -20,7 +20,7 @@ $$
   BEGIN
     FOR yksilo_index IN 1..yksiloiden_maara
       LOOP
-        SELECT tunnistus.generate_yksilo_id(concat('MOCKuser_testdata', yksilo_index::text)) INTO yid;
+        SELECT tunnistus.generate_yksilo_id(concat('MOCK:user_testdata', yksilo_index::text)) INTO yid;
 
 
         INSERT INTO yksilo(id) VALUES (yid) ON CONFLICT DO NOTHING;

--- a/src/main/java/fi/okm/jod/yksilo/config/LoginSuccessHandler.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/LoginSuccessHandler.java
@@ -9,6 +9,7 @@
 
 package fi.okm.jod.yksilo.config;
 
+import fi.okm.jod.yksilo.config.logging.LogMarker;
 import fi.okm.jod.yksilo.domain.JodUser;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -35,8 +36,9 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     if (authentication != null && authentication.getPrincipal() instanceof JodUser user) {
       log.atInfo()
+          .addMarker(LogMarker.AUDIT)
           .addKeyValue("userId", user.getId())
-          .log("AUDIT: User {} logged in", user.getId());
+          .log("User {} logged in", user.getId());
     }
 
     if (request.getSession(false) instanceof HttpSession s) {

--- a/src/main/java/fi/okm/jod/yksilo/config/ProfileDeletionHandler.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/ProfileDeletionHandler.java
@@ -9,6 +9,7 @@
 
 package fi.okm.jod.yksilo.config;
 
+import fi.okm.jod.yksilo.config.logging.LogMarker;
 import fi.okm.jod.yksilo.domain.JodUser;
 import fi.okm.jod.yksilo.service.profiili.YksiloService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,9 +27,14 @@ public class ProfileDeletionHandler implements LogoutHandler {
   @Override
   public void logout(
       HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-    if ("true".equals(request.getParameter("deletion"))
-        && authentication.getPrincipal() instanceof JodUser user) {
-      yksiloService.delete(user);
+    if (authentication != null && authentication.getPrincipal() instanceof JodUser user) {
+      if ("true".equals(request.getParameter("deletion"))) {
+        yksiloService.delete(user);
+      }
+      log.atInfo()
+          .addMarker(LogMarker.AUDIT)
+          .addKeyValue("userId", user.getId())
+          .log("User {} logged out", user.getId());
     }
   }
 }

--- a/src/main/java/fi/okm/jod/yksilo/config/logging/ImmutableMarker.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/logging/ImmutableMarker.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.config.logging;
+
+import java.util.Collections;
+import java.util.Iterator;
+import org.slf4j.Marker;
+
+public interface ImmutableMarker extends Marker {
+
+  @Override
+  default void add(Marker reference) {
+    throw new UnsupportedOperationException("ImmutableMarker does not support add()");
+  }
+
+  @Override
+  default boolean remove(Marker reference) {
+    return false;
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  default boolean hasChildren() {
+    return false;
+  }
+
+  @Override
+  default boolean hasReferences() {
+    return false;
+  }
+
+  @Override
+  default Iterator<Marker> iterator() {
+    return Collections.emptyIterator();
+  }
+
+  @Override
+  default boolean contains(Marker other) {
+    return false;
+  }
+
+  @Override
+  default boolean contains(String name) {
+    return false;
+  }
+}

--- a/src/main/java/fi/okm/jod/yksilo/config/logging/LogMarker.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/logging/LogMarker.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.config.logging;
+
+public enum LogMarker implements ImmutableMarker {
+  AUDIT;
+
+  @Override
+  public String getName() {
+    return name();
+  }
+}

--- a/src/main/java/fi/okm/jod/yksilo/config/mocklogin/MockJodUserImpl.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/mocklogin/MockJodUserImpl.java
@@ -96,4 +96,10 @@ public class MockJodUserImpl implements UserDetails, JodUser {
   public String getPersonId() {
     return username;
   }
+
+  @Override
+  @JsonIgnore
+  public String getQualifiedPersonId() {
+    return "MOCK:" + username;
+  }
 }

--- a/src/main/java/fi/okm/jod/yksilo/config/suomifi/JodSaml2Principal.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/suomifi/JodSaml2Principal.java
@@ -70,6 +70,17 @@ final class JodSaml2Principal extends DefaultSaml2AuthenticatedPrincipal impleme
   }
 
   @JsonIgnore
+  @Override
+  public String getQualifiedPersonId() {
+    return getAttribute(PersonIdentifierType.FIN.getAttribute())
+        .map(PersonIdentifierType.FIN::asQualifiedIdentifier)
+        .orElse(
+            getAttribute(PersonIdentifierType.EIDAS.getAttribute())
+                .map(PersonIdentifierType.EIDAS::asQualifiedIdentifier)
+                .orElse(null));
+  }
+
+  @JsonIgnore
   public Optional<String> getAttribute(Attribute attribute) {
     return Optional.ofNullable(getFirstAttribute(attribute.getUri()));
   }

--- a/src/main/java/fi/okm/jod/yksilo/config/suomifi/Saml2LoginConfig.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/suomifi/Saml2LoginConfig.java
@@ -16,6 +16,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 import fi.okm.jod.yksilo.config.LoginSuccessHandler;
 import fi.okm.jod.yksilo.config.ProfileDeletionHandler;
 import fi.okm.jod.yksilo.config.SessionLoginAttribute;
+import fi.okm.jod.yksilo.config.logging.LogMarker;
 import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.service.profiili.YksiloService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -267,7 +268,9 @@ public class Saml2LoginConfig {
       var queryParam = "";
       if (exception != null) {
         queryParam = "?error=AUTHENTICATION_FAILURE";
-        log.warn("Authentication failure: {}", exception.getMessage());
+        log.atWarn()
+            .addMarker(LogMarker.AUDIT)
+            .log("Authentication failure: {}", exception.getMessage());
       }
       redirectStrategy.sendRedirect(request, response, "/" + queryParam);
     }

--- a/src/main/java/fi/okm/jod/yksilo/domain/JodUser.java
+++ b/src/main/java/fi/okm/jod/yksilo/domain/JodUser.java
@@ -22,6 +22,8 @@ public interface JodUser {
 
   String getPersonId();
 
+  String getQualifiedPersonId();
+
   default Optional<String> getAttribute(Attribute attribute) {
     return Optional.empty();
   }

--- a/src/main/java/fi/okm/jod/yksilo/dto/profiili/YksiloDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/profiili/YksiloDto.java
@@ -12,8 +12,11 @@ package fi.okm.jod.yksilo.dto.profiili;
 import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.domain.PersonIdentifierType;
 import fi.okm.jod.yksilo.domain.Sukupuoli;
+import fi.okm.jod.yksilo.validation.LanguageCode;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record YksiloDto(
     @Schema(accessMode = Schema.AccessMode.READ_ONLY) PersonIdentifierType tunnisteTyyppi,
@@ -23,5 +26,6 @@ public record YksiloDto(
     Integer syntymavuosi,
     Sukupuoli sukupuoli,
     @Pattern(regexp = "[0-9]{3}") String kotikunta,
-    @Pattern(regexp = "[a-z]{2}") String aidinkieli,
-    Kieli valittuKieli) {}
+    @LanguageCode String aidinkieli,
+    Kieli valittuKieli,
+    @Email @Size(max = 254) String email) {}

--- a/src/main/java/fi/okm/jod/yksilo/dto/profiili/export/YksiloExportDto.java
+++ b/src/main/java/fi/okm/jod/yksilo/dto/profiili/export/YksiloExportDto.java
@@ -24,6 +24,7 @@ public record YksiloExportDto(
     String kotikunta,
     String aidinkieli,
     Kieli valittuKieli,
+    String email,
     Set<TyopaikkaExportDto> tyopaikat,
     Set<KoulutusKokonaisuusExportDto> koulutusKokonaisuudet,
     Set<ToimintoExportDto> toiminnot,

--- a/src/main/java/fi/okm/jod/yksilo/repository/YksiloRepository.java
+++ b/src/main/java/fi/okm/jod/yksilo/repository/YksiloRepository.java
@@ -11,12 +11,14 @@ package fi.okm.jod.yksilo.repository;
 
 import fi.okm.jod.yksilo.entity.Yksilo;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.lang.Nullable;
 
 public interface YksiloRepository extends JpaRepository<Yksilo, UUID> {
 
@@ -25,6 +27,12 @@ public interface YksiloRepository extends JpaRepository<Yksilo, UUID> {
 
   @Query(value = "SELECT tunnistus.remove_yksilo_id(:yksiloId)", nativeQuery = true)
   void removeId(UUID yksiloId);
+
+  @Query(value = "SELECT tunnistus.update_yksilo_email(:henkiloId, :email)", nativeQuery = true)
+  void updateEmail(String henkiloId, @Nullable String email);
+
+  @Query(value = "SELECT tunnistus.read_yksilo_email(:henkiloId)", nativeQuery = true)
+  Optional<String> getEmail(String henkiloId);
 
   @Query(value = "SELECT k.uri FROM Yksilo y JOIN y.osaamisKiinnostukset k WHERE y = :yksilo")
   Set<String> findOsaamisKiinnostukset(Yksilo yksilo);

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/ExportMapper.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/ExportMapper.java
@@ -45,7 +45,7 @@ public final class ExportMapper {
 
   private ExportMapper() {}
 
-  public static YksiloExportDto mapYksilo(Yksilo entity) {
+  public static YksiloExportDto mapYksilo(Yksilo entity, String email) {
     return entity == null
         ? null
         : new YksiloExportDto(
@@ -58,6 +58,7 @@ public final class ExportMapper {
             entity.getKotikunta(),
             entity.getAidinkieli(),
             entity.getValittuKieli(),
+            email,
             entity.getTyopaikat().stream()
                 .map(ExportMapper::mapTyopaikka)
                 .collect(Collectors.toSet()),

--- a/src/main/java/fi/okm/jod/yksilo/validation/LanguageCode.java
+++ b/src/main/java/fi/okm/jod/yksilo/validation/LanguageCode.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.validation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = LanguageCodeValidator.class)
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+public @interface LanguageCode {
+  String message() default "ISO 639-1 alpha-2 language code required";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/fi/okm/jod/yksilo/validation/LanguageCodeValidator.java
+++ b/src/main/java/fi/okm/jod/yksilo/validation/LanguageCodeValidator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.yksilo.validation;
+
+import jakarta.validation.ConstraintValidator;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LanguageCodeValidator implements ConstraintValidator<LanguageCode, String> {
+
+  private final Set<String> languageCodes;
+
+  public LanguageCodeValidator(@Value("${jod.koodistot.kieli}") Set<String> languageCodes) {
+    this.languageCodes = languageCodes;
+  }
+
+  @Override
+  public boolean isValid(String value, jakarta.validation.ConstraintValidatorContext context) {
+    return value == null || value.length() == 2 && languageCodes.contains(value);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -114,3 +114,7 @@ jod:
   ai-tunnistus:
     osaamiset:
       endpoint: ""
+  koodistot:
+    # ISO-639-1 alpha-2 codes
+    # Source: https://data.stat.fi/api/classifications/v2/classifications/kieli_1_20101115
+    kieli: "aa,ab,ae,af,ak,am,ar,an,as,av,ay,az,ba,be,bg,bh,bi,bm,bn,bo,br,bs,ca,ce,ch,co,cr,cs,cu,cv,cy,da,de,dv,dz,ee,el,en,eo,es,et,eu,fa,ff,fi,fj,fo,fr,fy,ga,gd,gl,gn,gu,gv,ha,he,hi,ho,hr,ht,hu,hy,hz,ia,id,ie,ig,ii,ik,io,is,it,iu,ja,jv,ka,kg,ki,kj,kk,kl,km,kn,ko,kr,ks,ku,kv,kw,ky,la,lb,lg,ln,li,lo,lt,lu,lv,mg,mh,mi,mk,ml,mn,mr,ms,mt,my,na,nb,nd,ne,ng,nl,nn,no,nr,nv,ny,oc,oj,om,or,os,pa,pi,pl,ps,pt,qu,rm,rn,ro,ru,rw,sa,sc,sd,se,sg,si,sk,sl,sm,sn,so,sq,sr,ss,st,su,sv,sw,ta,te,tg,th,ti,tk,tl,tn,to,tr,ts,tt,tw,ty,ug,uk,ur,uz,wa,ve,vi,vo,wo,xh,yi,yo,za,zh,zu"

--- a/src/test/java/fi/okm/jod/yksilo/controller/profiili/YksiloControllerTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/controller/profiili/YksiloControllerTest.java
@@ -89,6 +89,6 @@ class YksiloControllerTest {
   }
 
   private static YksiloDto createYksiloDto() {
-    return new YksiloDto(null, true, false, false, null, null, null, null, null);
+    return new YksiloDto(null, true, false, false, null, null, null, null, null, null);
   }
 }

--- a/src/test/java/fi/okm/jod/yksilo/service/AbstractServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/AbstractServiceTest.java
@@ -9,11 +9,11 @@
 
 package fi.okm.jod.yksilo.service;
 
+import fi.okm.jod.yksilo.domain.FinnishPersonIdentifier;
 import fi.okm.jod.yksilo.entity.Yksilo;
 import fi.okm.jod.yksilo.repository.YksiloRepository;
 import fi.okm.jod.yksilo.testutil.TestJodUser;
 import fi.okm.jod.yksilo.testutil.TestUtil;
-import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,16 +44,19 @@ public abstract class AbstractServiceTest {
 
   @BeforeEach
   public void setup() {
-    var yksilo = new Yksilo(yksiloRepository.findIdByHenkiloId("TEST:" + UUID.randomUUID()));
+    var id1 = FinnishPersonIdentifier.of("010199-9986");
+    var id2 = FinnishPersonIdentifier.of("010199-9997");
+
+    var yksilo = new Yksilo(yksiloRepository.findIdByHenkiloId("TEST:" + id1.asString()));
     yksilo.setTervetuloapolku(true);
-    this.user = new TestJodUser(entityManager.persist(yksilo).getId());
+    this.user = new TestJodUser(entityManager.persist(yksilo).getId(), id1);
     // Create a second user with a different ID for testing purposes
     this.user2 =
         new TestJodUser(
             entityManager
-                .persist(
-                    new Yksilo(yksiloRepository.findIdByHenkiloId("TEST:" + UUID.randomUUID())))
-                .getId());
+                .persist(new Yksilo(yksiloRepository.findIdByHenkiloId("TEST:" + id2.asString())))
+                .getId(),
+            id2);
   }
 
   /** Simulates commit by flushing and clearing the entity manager. */

--- a/src/test/java/fi/okm/jod/yksilo/service/profiili/YksiloServiceTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/profiili/YksiloServiceTest.java
@@ -67,7 +67,8 @@ class YksiloServiceTest extends AbstractServiceTest {
             Sukupuoli.NAINEN,
             user.getAttribute(Attribute.KOTIKUNTA_KUNTANUMERO).get(),
             "fi",
-            Kieli.EN);
+            Kieli.EN,
+            "user@example.org");
     service.update(user, tiedot);
     assertEquals(tiedot, service.get(user));
   }
@@ -76,7 +77,18 @@ class YksiloServiceTest extends AbstractServiceTest {
   void shouldNotChangeIdentificationAttributes() {
     shouldUpdateTiedot();
 
-    var tiedot = new YksiloDto(null, true, true, true, 2000, Sukupuoli.MIES, "200", "fi", Kieli.EN);
+    var tiedot =
+        new YksiloDto(
+            null,
+            true,
+            true,
+            true,
+            2000,
+            Sukupuoli.MIES,
+            "200",
+            "fi",
+            Kieli.EN,
+            "user@example.org");
     assertThrows(ServiceValidationException.class, () -> service.update(user, tiedot));
   }
 }

--- a/src/test/java/fi/okm/jod/yksilo/testutil/TestJodUser.java
+++ b/src/test/java/fi/okm/jod/yksilo/testutil/TestJodUser.java
@@ -15,9 +15,10 @@ import fi.okm.jod.yksilo.domain.JodUser;
 import java.util.Optional;
 import java.util.UUID;
 
-public record TestJodUser(UUID id) implements JodUser {
-  private static final FinnishPersonIdentifier personIdentifier =
-      FinnishPersonIdentifier.of("010199-9986");
+public record TestJodUser(UUID id, FinnishPersonIdentifier personIdentifier) implements JodUser {
+  public TestJodUser(UUID id) {
+    this(id, FinnishPersonIdentifier.of("010199-9986"));
+  }
 
   @Override
   public UUID getId() {
@@ -48,7 +49,8 @@ public record TestJodUser(UUID id) implements JodUser {
     };
   }
 
-  public static JodUser of(String uuid) {
-    return new TestJodUser(UUID.fromString(uuid));
+  @Override
+  public String getQualifiedPersonId() {
+    return "TEST:" + getPersonId();
   }
 }

--- a/src/test/resources/db/migration/R__000_mock_tunnistus.sql
+++ b/src/test/resources/db/migration/R__000_mock_tunnistus.sql
@@ -2,23 +2,26 @@
 CREATE SCHEMA IF NOT EXISTS tunnistus;
 
 CREATE TABLE IF NOT EXISTS tunnistus.henkilo (
-    yksilo_id  UUID PRIMARY KEY,
-    henkilo_id VARCHAR(300) NOT NULL UNIQUE
+  yksilo_id  UUID PRIMARY KEY,
+  henkilo_id VARCHAR(300) NOT NULL UNIQUE,
+  email      VARCHAR(254),
+  luotu      TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  muokattu   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE OR REPLACE FUNCTION tunnistus.generate_yksilo_id(henkilo_id VARCHAR(300)) RETURNS UUID AS
 $$
 DECLARE
-    id UUID;
+  id UUID;
 BEGIN
-    INSERT INTO tunnistus.henkilo(yksilo_id, henkilo_id)
-    VALUES (gen_random_uuid(), $1)
-    ON CONFLICT DO NOTHING
-    RETURNING yksilo_id INTO id;
-    IF id IS NULL THEN
-        SELECT h.yksilo_id FROM tunnistus.henkilo h WHERE h.henkilo_id = $1 INTO id;
-    END IF;
-    RETURN id;
+  INSERT INTO tunnistus.henkilo(yksilo_id, henkilo_id)
+  VALUES (gen_random_uuid(), $1)
+  ON CONFLICT DO NOTHING
+  RETURNING yksilo_id INTO id;
+  IF id IS NULL THEN
+    SELECT h.yksilo_id FROM tunnistus.henkilo h WHERE h.henkilo_id = $1 INTO id;
+  END IF;
+  RETURN id;
 END
 $$ LANGUAGE PLPGSQL;
 
@@ -26,7 +29,26 @@ CREATE OR REPLACE FUNCTION tunnistus.remove_yksilo_id(yksilo_id UUID) RETURNS UU
 $$
 DELETE
 FROM tunnistus.henkilo
-WHERE yksilo_id = $1
+WHERE henkilo.yksilo_id = $1
 RETURNING yksilo_id
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION tunnistus.read_yksilo_email(henkilo_id VARCHAR(300)) RETURNS VARCHAR(254) AS
 $$
-LANGUAGE SQL;
+DECLARE
+  email VARCHAR(254);
+BEGIN
+  SELECT h.email INTO email FROM tunnistus.henkilo h WHERE h.henkilo_id = $1;
+  RETURN email;
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE OR REPLACE FUNCTION tunnistus.update_yksilo_email(henkilo_id VARCHAR(300), email VARCHAR(254)) RETURNS VOID AS
+$$
+BEGIN
+  UPDATE tunnistus.henkilo
+  SET email    = $2,
+      muokattu = CURRENT_TIMESTAMP
+  WHERE henkilo.henkilo_id = $1;
+END
+$$ LANGUAGE PLPGSQL;


### PR DESCRIPTION
## Description
- Add email attribute (tunnistus-schema)
- Add email to export
- Add language code validation (äidinkieli)
- Improve audit logging

See also:
https://github.com/Opetushallitus/jod-infra/pull/115
https://github.com/Opetushallitus/jod-yksilo-ui/pull/573

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1842

