### PR TITLE
OPHJOD-3375: Relax SAML2 attribute validation

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/config/login/JodAuthenticationProperties.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/login/JodAuthenticationProperties.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 
 @ConfigurationProperties(prefix = "jod.authentication")
 @Getter
@@ -24,10 +25,14 @@ public class JodAuthenticationProperties {
 
   private final String provider;
   private final Map<URI, PersonIdentifierType> supportedMethods;
+  private final boolean lenient;
 
   @ConstructorBinding
   JodAuthenticationProperties(
-      String provider, Map<PersonIdentifierType, List<URI>> supportedMethods) {
+      String provider,
+      Map<PersonIdentifierType, List<URI>> supportedMethods,
+      @DefaultValue("false") boolean lenient) {
+    this.lenient = lenient;
     this.provider = provider;
     // Reversing the map is intentional: PersonIdentifier -> URI is easier to override
     // using SSM parameters, but URI -> PersonIdentifier is more convenient to use

--- a/src/main/java/fi/okm/jod/yksilo/config/login/ResponseTokenConverter.java
+++ b/src/main/java/fi/okm/jod/yksilo/config/login/ResponseTokenConverter.java
@@ -132,22 +132,33 @@ class ResponseTokenConverter implements Converter<ResponseToken, Saml2Authentica
       Kieli selectedLanguage,
       PersonIdentifierType pid) {
 
-    var personId = getAttribute(assertionAccessor, pid.getAttribute()).orElse(null);
+    final var personId = getAttribute(assertionAccessor, pid.getAttribute()).orElse(null);
     if (personId == null || personId.isBlank()) {
       throw new BadCredentialsException("Invalid person identifier");
     }
 
-    var etunimet =
-        getAttribute(assertionAccessor, Attribute.FIRST_NAME)
-            .orElseThrow(() -> new BadCredentialsException("Missing first name"));
-    var kutsumanimi = getAttribute(assertionAccessor, Attribute.GIVEN_NAME).orElse(etunimet);
-    var sukunimi =
-        getAttribute(assertionAccessor, Attribute.SN)
-            .or(() -> getAttribute(assertionAccessor, Attribute.FAMILY_NAME))
-            .orElseThrow(() -> new BadCredentialsException("Missing family name"));
+    final String sukunimi;
+    final String etunimet;
+    if (authenticationProperties.isLenient()) {
+      sukunimi =
+          getAttribute(assertionAccessor, Attribute.SN)
+              .or(() -> getAttribute(assertionAccessor, Attribute.FAMILY_NAME))
+              .or(() -> getAttribute(assertionAccessor, Attribute.CN))
+              .orElseThrow(() -> new BadCredentialsException("Name required"));
+      etunimet = getAttribute(assertionAccessor, Attribute.FIRST_NAME).orElse(null);
+    } else {
+      sukunimi =
+          getAttribute(assertionAccessor, Attribute.SN)
+              .or(() -> getAttribute(assertionAccessor, Attribute.FAMILY_NAME))
+              .orElseThrow(() -> new BadCredentialsException("Family name required"));
+      etunimet =
+          getAttribute(assertionAccessor, Attribute.FIRST_NAME)
+              .orElseThrow(() -> new BadCredentialsException("First name required"));
+    }
+    final var kutsumanimi = getAttribute(assertionAccessor, Attribute.GIVEN_NAME).orElse(etunimet);
 
-    var henkiloId = pid.asQualifiedIdentifier(personId);
-    var tunnistusData = yksilot.findTunnistusDataByHenkiloId(henkiloId).orElse(null);
+    final var henkiloId = pid.asQualifiedIdentifier(personId);
+    final var tunnistusData = yksilot.findTunnistusDataByHenkiloId(henkiloId).orElse(null);
 
     final String oppijanumero;
     var onr = tunnistusData != null ? tunnistusData.oppijanumero() : null;


### PR DESCRIPTION
## Description

Relax SAML2 attribute validation. 
Use common name if family name is not present, and allow missing first name.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-3375
