### PR TITLE
OPHJOD-3454: Group experience in CV import

### DIFF
--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/cv/CvResponse.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/cv/CvResponse.java
@@ -19,8 +19,38 @@ record CvResponse(
     List<Education> education,
     @JsonProperty("other_activities") List<Activity> otherActivities) {
 
+  /**
+   * Work experience at a single employer. In addition to the grouped format, the fields of the
+   * legacy flat format, where each entry described a single position, are accepted, as messages in
+   * the old format may still be queued.
+   */
   record WorkExperience(
       String company,
+      List<Position> positions,
+      String title,
+      @JsonProperty("start_date") LocalDate startDate,
+      @JsonProperty("end_date") LocalDate endDate,
+      String location,
+      String description,
+      List<String> skills) {
+
+    WorkExperience(String company, List<Position> positions) {
+      this(company, positions, null, null, null, null, null, null);
+    }
+
+    /** The positions, whether given in the grouped or the legacy flat format. */
+    List<Position> allPositions() {
+      if (positions != null) {
+        return positions;
+      }
+      if (title == null && startDate == null) {
+        return List.of();
+      }
+      return List.of(new Position(title, startDate, endDate, location, description, skills));
+    }
+  }
+
+  record Position(
       String title,
       @JsonProperty("start_date") LocalDate startDate,
       @JsonProperty("end_date") LocalDate endDate,
@@ -28,8 +58,36 @@ record CvResponse(
       String description,
       List<String> skills) {}
 
+  /**
+   * Education at a single institution. In addition to the grouped format, the fields of the legacy
+   * flat format, where each entry described a single degree, are accepted, as messages in the old
+   * format may still be queued.
+   */
   record Education(
       String institution,
+      List<Degree> degrees,
+      String degree,
+      @JsonProperty("start_date") LocalDate startDate,
+      @JsonProperty("end_date") LocalDate endDate,
+      String details) {
+
+    Education(String institution, List<Degree> degrees) {
+      this(institution, degrees, null, null, null, null);
+    }
+
+    /** The degrees, whether given in the grouped or the legacy flat format. */
+    List<Degree> allDegrees() {
+      if (degrees != null) {
+        return degrees;
+      }
+      if (degree == null && startDate == null) {
+        return List.of();
+      }
+      return List.of(new Degree(degree, startDate, endDate, details));
+    }
+  }
+
+  record Degree(
       String degree,
       @JsonProperty("start_date") LocalDate startDate,
       @JsonProperty("end_date") LocalDate endDate,

--- a/src/main/java/fi/okm/jod/yksilo/service/profiili/cv/CvResponseMapper.java
+++ b/src/main/java/fi/okm/jod/yksilo/service/profiili/cv/CvResponseMapper.java
@@ -9,6 +9,8 @@
 
 package fi.okm.jod.yksilo.service.profiili.cv;
 
+import static java.util.stream.Collectors.toCollection;
+
 import fi.okm.jod.yksilo.domain.Kieli;
 import fi.okm.jod.yksilo.domain.LocalizedString;
 import fi.okm.jod.yksilo.domain.TuontiLahde;
@@ -22,15 +24,17 @@ import fi.okm.jod.yksilo.dto.profiili.TyopaikkaDto;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-/** Maps a flattened {@link CvResponse} to {@link CvTehtavaDto.Tulos}. */
+/** Maps a {@link CvResponse} to {@link CvTehtavaDto.Tulos}. */
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -66,29 +70,49 @@ class CvResponseMapper {
     return result.isEmpty();
   }
 
+  /**
+   * Maps the items of a group (positions of an employer, degrees of an institution), dropping the
+   * invalid ones. A group left without any valid items fails validation and is dropped as a whole.
+   */
+  private <T, R> Set<R> mapValid(
+      List<T> items, Function<T, R> mapper, Set<ConstraintViolation<?>> violations) {
+    if (items == null) {
+      return Set.of();
+    }
+    return items.stream()
+        .map(mapper)
+        .filter(it -> isValid(it, violations))
+        .collect(toCollection(LinkedHashSet::new));
+  }
+
   private List<KoulutusKokonaisuusDto> mapEducations(
       List<CvResponse.Education> educations, Kieli kieli, Set<ConstraintViolation<?>> violations) {
     if (educations == null) {
       return List.of();
     }
     return educations.stream()
-        .map(e -> mapEducation(e, kieli))
+        .map(e -> mapEducation(e, kieli, violations))
         .filter(it -> isValid(it, violations))
         .toList();
   }
 
-  private KoulutusKokonaisuusDto mapEducation(CvResponse.Education education, Kieli kieli) {
-    var nimi = localizedString(education.institution(), kieli);
-    var koulutus =
-        KoulutusDto.builder()
-            .id(UUID.randomUUID())
-            .nimi(localizedString(education.degree(), kieli))
-            .kuvaus(localizedString(education.details(), kieli))
-            .alkuPvm(education.startDate())
-            .loppuPvm(education.endDate())
-            .build();
+  private KoulutusKokonaisuusDto mapEducation(
+      CvResponse.Education education, Kieli kieli, Set<ConstraintViolation<?>> violations) {
     return new KoulutusKokonaisuusDto(
-        UUID.randomUUID(), nimi, TuontiLahde.CV_TUONTI, Set.of(koulutus));
+        UUID.randomUUID(),
+        localizedString(education.institution(), kieli),
+        TuontiLahde.CV_TUONTI,
+        mapValid(education.allDegrees(), degree -> mapKoulutus(degree, kieli), violations));
+  }
+
+  private KoulutusDto mapKoulutus(CvResponse.Degree degree, Kieli kieli) {
+    return KoulutusDto.builder()
+        .id(UUID.randomUUID())
+        .nimi(localizedString(degree.degree(), kieli))
+        .kuvaus(localizedString(degree.details(), kieli))
+        .alkuPvm(degree.startDate())
+        .loppuPvm(degree.endDate())
+        .build();
   }
 
   private List<TyopaikkaDto> mapWorkExperiences(
@@ -99,22 +123,31 @@ class CvResponseMapper {
       return List.of();
     }
     return workExperiences.stream()
-        .map(e -> mapWorkExperience(e, kieli))
+        .map(e -> mapWorkExperience(e, kieli, violations))
         .filter(it -> isValid(it, violations))
         .toList();
   }
 
-  private TyopaikkaDto mapWorkExperience(CvResponse.WorkExperience workExperience, Kieli kieli) {
-    var nimi = localizedString(workExperience.company(), kieli);
-    var toimenkuva =
-        new ToimenkuvaDto(
-            UUID.randomUUID(),
-            localizedString(workExperience.title(), kieli),
-            localizedString(workExperience.description(), kieli),
-            workExperience.startDate(),
-            workExperience.endDate(),
-            null);
-    return new TyopaikkaDto(UUID.randomUUID(), nimi, TuontiLahde.CV_TUONTI, Set.of(toimenkuva));
+  private TyopaikkaDto mapWorkExperience(
+      CvResponse.WorkExperience workExperience,
+      Kieli kieli,
+      Set<ConstraintViolation<?>> violations) {
+    return new TyopaikkaDto(
+        UUID.randomUUID(),
+        localizedString(workExperience.company(), kieli),
+        TuontiLahde.CV_TUONTI,
+        mapValid(
+            workExperience.allPositions(), position -> mapToimenkuva(position, kieli), violations));
+  }
+
+  private ToimenkuvaDto mapToimenkuva(CvResponse.Position position, Kieli kieli) {
+    return new ToimenkuvaDto(
+        UUID.randomUUID(),
+        localizedString(position.title(), kieli),
+        localizedString(position.description(), kieli),
+        position.startDate(),
+        position.endDate(),
+        null);
   }
 
   private List<TeemaDto> mapActivities(

--- a/src/test/java/fi/okm/jod/yksilo/service/profiili/cv/CvResponseMapperTest.java
+++ b/src/test/java/fi/okm/jod/yksilo/service/profiili/cv/CvResponseMapperTest.java
@@ -48,13 +48,26 @@ class CvResponseMapperTest {
     return new CvResponse(null, null, List.of(items));
   }
 
+  private static CvResponse.Position position(
+      String title, LocalDate start, LocalDate end, String description) {
+    return new CvResponse.Position(title, start, end, null, description, null);
+  }
+
+  private static CvResponse.Degree degree(
+      String name, LocalDate start, LocalDate end, String details) {
+    return new CvResponse.Degree(name, start, end, details);
+  }
+
   @Test
   void shouldMapValidResponse() {
     var response =
         new CvResponse(
             List.of(
-                new CvResponse.WorkExperience("Company", "Title", DATE, null, null, "Desc", null)),
-            List.of(new CvResponse.Education("University", "Degree", DATE, null, "Details")),
+                new CvResponse.WorkExperience(
+                    "Company", List.of(position("Title", DATE, null, "Desc")))),
+            List.of(
+                new CvResponse.Education(
+                    "University", List.of(degree("Degree", DATE, null, "Details")))),
             List.of(new CvResponse.Activity("Hobby", "Name", "Description", DATE, null)));
 
     var tulos = map(response);
@@ -62,6 +75,104 @@ class CvResponseMapperTest {
     assertThat(tulos.koulutuskokonaisuudet()).hasSize(1);
     assertThat(tulos.tyopaikat()).hasSize(1);
     assertThat(tulos.teemat()).hasSize(1);
+  }
+
+  @Test
+  void shouldMapLegacyFlatResponse() {
+    var response =
+        new CvResponse(
+            List.of(
+                new CvResponse.WorkExperience(
+                    "Company", null, "Title", DATE, null, null, "Desc", null)),
+            List.of(new CvResponse.Education("University", null, "Degree", DATE, null, "Details")),
+            null);
+
+    var tulos = map(response);
+
+    assertThat(tulos.tyopaikat())
+        .singleElement()
+        .satisfies(it -> assertThat(it.toimenkuvat()).hasSize(1));
+    assertThat(tulos.koulutuskokonaisuudet())
+        .singleElement()
+        .satisfies(it -> assertThat(it.koulutukset()).hasSize(1));
+  }
+
+  @Test
+  void shouldMapAllPositionsOfEmployer() {
+    var tulos =
+        map(
+            withWork(
+                new CvResponse.WorkExperience(
+                    "Company",
+                    List.of(
+                        position("Current", LocalDate.of(2022, 3, 1), null, "Desc"),
+                        position(
+                            "Previous",
+                            LocalDate.of(2019, 6, 1),
+                            LocalDate.of(2022, 2, 28),
+                            "Desc")))));
+
+    assertThat(tulos.tyopaikat())
+        .singleElement()
+        .satisfies(it -> assertThat(it.toimenkuvat()).hasSize(2));
+  }
+
+  @Test
+  void shouldMapAllDegreesOfInstitution() {
+    var tulos =
+        map(
+            withEducation(
+                new CvResponse.Education(
+                    "University",
+                    List.of(
+                        degree("M.S.", LocalDate.of(2013, 1, 1), LocalDate.of(2015, 12, 31), null),
+                        degree(
+                            "B.S.", LocalDate.of(2009, 1, 1), LocalDate.of(2013, 12, 31), null)))));
+
+    assertThat(tulos.koulutuskokonaisuudet())
+        .singleElement()
+        .satisfies(it -> assertThat(it.koulutukset()).hasSize(2));
+  }
+
+  @Test
+  void shouldKeepValidPositionsAndExcludeInvalid() {
+    var tulos =
+        map(
+            withWork(
+                new CvResponse.WorkExperience(
+                    "Company",
+                    List.of(
+                        position(null, DATE, null, "Desc"),
+                        position("Valid", DATE, null, "Desc")))));
+
+    assertThat(tulos.tyopaikat())
+        .singleElement()
+        .satisfies(it -> assertThat(it.toimenkuvat()).hasSize(1));
+  }
+
+  @Test
+  void shouldExcludeWorkExperienceWithoutValidPositions() {
+    var tulos =
+        map(
+            withWork(
+                new CvResponse.WorkExperience("Company", null),
+                new CvResponse.WorkExperience("Company", List.of()),
+                new CvResponse.WorkExperience(
+                    "Company", List.of(position("Title", null, null, null)))));
+
+    assertThat(tulos.tyopaikat()).isEmpty();
+  }
+
+  @Test
+  void shouldExcludeEducationWithoutValidDegrees() {
+    var tulos =
+        map(
+            withEducation(
+                new CvResponse.Education("University", null),
+                new CvResponse.Education("University", List.of()),
+                new CvResponse.Education("University", List.of(degree(null, DATE, null, null)))));
+
+    assertThat(tulos.koulutuskokonaisuudet()).isEmpty();
   }
 
   @Test
@@ -81,57 +192,73 @@ class CvResponseMapperTest {
     var tulos =
         map(
             withEducation(
-                new CvResponse.Education(null, "Degree", DATE, null, null),
-                new CvResponse.Education("Valid University", "Degree", DATE, null, null)));
+                new CvResponse.Education(null, List.of(degree("Degree", DATE, null, null))),
+                new CvResponse.Education(
+                    "Valid University", List.of(degree("Degree", DATE, null, null)))));
 
     assertThat(tulos.koulutuskokonaisuudet()).hasSize(1);
   }
 
   @Test
   void shouldExcludeEducationWithBlankInstitution() {
-    var tulos = map(withEducation(new CvResponse.Education("  ", "Degree", DATE, null, null)));
+    var tulos =
+        map(
+            withEducation(
+                new CvResponse.Education("  ", List.of(degree("Degree", DATE, null, null)))));
 
     assertThat(tulos.koulutuskokonaisuudet()).isEmpty();
   }
 
   @Test
-  void shouldExcludeEducationWithNullDegree() {
-    var tulos = map(withEducation(new CvResponse.Education("University", null, DATE, null, null)));
+  void shouldExcludeDegreeWithNullName() {
+    var tulos =
+        map(
+            withEducation(
+                new CvResponse.Education(
+                    "University",
+                    List.of(degree(null, DATE, null, null), degree("Degree", DATE, null, null)))));
 
-    assertThat(tulos.koulutuskokonaisuudet()).isEmpty();
+    assertThat(tulos.koulutuskokonaisuudet())
+        .singleElement()
+        .satisfies(it -> assertThat(it.koulutukset()).hasSize(1));
   }
 
   @Test
   void shouldExcludeWorkExperienceWithNullCompany() {
     var tulos =
-        map(withWork(new CvResponse.WorkExperience(null, "Title", DATE, null, null, null, null)));
-
-    assertThat(tulos.tyopaikat()).isEmpty();
-  }
-
-  @Test
-  void shouldExcludeWorkExperienceWithNullStartDate() {
-    var tulos =
         map(
             withWork(
-                new CvResponse.WorkExperience("Company", "Title", null, null, null, null, null)));
+                new CvResponse.WorkExperience(null, List.of(position("Title", DATE, null, null)))));
 
     assertThat(tulos.tyopaikat()).isEmpty();
   }
 
   @Test
-  void shouldExcludeWorkExperienceWithInvalidInterval() {
+  void shouldExcludePositionWithNullStartDate() {
     var tulos =
         map(
             withWork(
                 new CvResponse.WorkExperience(
                     "Company",
-                    "Title",
-                    LocalDate.of(2020, 6, 1),
-                    LocalDate.of(2020, 1, 1),
-                    null,
-                    null,
-                    null)));
+                    List.of(
+                        position("Title", null, null, null),
+                        position("Other", DATE, null, null)))));
+
+    assertThat(tulos.tyopaikat())
+        .singleElement()
+        .satisfies(it -> assertThat(it.toimenkuvat()).hasSize(1));
+  }
+
+  @Test
+  void shouldExcludePositionWithInvalidInterval() {
+    var tulos =
+        map(
+            withWork(
+                new CvResponse.WorkExperience(
+                    "Company",
+                    List.of(
+                        position(
+                            "Title", LocalDate.of(2020, 6, 1), LocalDate.of(2020, 1, 1), null)))));
 
     assertThat(tulos.tyopaikat()).isEmpty();
   }


### PR DESCRIPTION
## Description
Support new CV extraction response format that has employer/position and education/degree groups.
Backwards compatible with the old format.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-3454
